### PR TITLE
Revamp WireMock recording workflow

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -11,7 +11,7 @@
 | ✅ | Settings & theme | `loadSettings`, `saveSettings`, and `toggleTheme` persist host/port, timeout, auth header, cache toggle, and UI theme across sessions.【F:js/main.js†L22-L138】【F:js/main.js†L344-L420】 |
 | ✅ | Notifications & status UI | `NotificationManager` plus helper badges keep connection, cache, and toast messaging coherent across flows.【F:js/features.js†L230-L260】【F:js/features.js†L2584-L2662】 |
 | ⚠️ | Cache service depth | `refreshImockCache`, `regenerateImockCache`, and scheduled validation rebuild the cache mapping and reset optimistic queues, but the integration still needs live end-to-end validation.【F:js/features.js†L1988-L2107】【F:js/features.js†L2584-L2662】 |
-| ⚠️ | Recording workflow | `startRecording`, `stopRecording`, and `takeRecordingSnapshot` hit the endpoints, yet the Recording tab ignores input fields and never populates `recordings-list`.【F:js/features.js†L1624-L1704】【F:index.html†L324-L413】 |
+| ✅ | Recording workflow | Recording helpers parse full start/snapshot specs, persist preferences, surface recorder status, render captured mappings, and expose JSON export via `initializeRecordingForm`, `startRecording`, `stopRecording`, `takeRecordingSnapshot`, and `downloadRecordingResults`.【F:js/features.js†L1599-L2219】【F:index.html†L333-L414】 |
 | ⚠️ | Auto-refresh toggle | Settings capture interval preferences, but no interval timer runs, so updates remain manual unless the cache pipeline triggers them.【F:js/main.js†L250-L344】 |
 | 🚧 | Demo mode | `loadMockData` only raises a toast and does not stage sample mappings or requests.【F:js/features.js†L2728-L2738】 |
 | 🚧 | Import/export buttons | UI buttons call undefined `exportMappings`, `exportRequests`, `importMappings`, and `importAndReplace`, resulting in console errors when clicked.【F:index.html†L120-L211】【F:js/features.js†L2686-L2727】 |
@@ -27,7 +27,7 @@
 | ⚠️ | Offline worker pool | `WorkerPool` skips instantiation on `file://`, so heavy JSON operations fall back to the main thread when the editor runs directly from disk.【F:editor/performance-optimizations.js†L121-L214】 |
 
 ## Backlog highlights
-- Wire the Recording tab inputs and list rendering to the existing helper responses.【F:index.html†L324-L413】【F:js/features.js†L1624-L1704】
+- Extend snapshot ergonomics with presets, quick ID pickers, and richer mapping metadata in the results list.【F:index.html†L333-L414】【F:js/features.js†L1821-L2219】
 - Implement Import/Export handlers or hide the buttons until the workflows exist.【F:index.html†L120-L211】【F:js/features.js†L2686-L2727】
 - Add a functional Demo Mode data loader for offline demos.【F:js/features.js†L2728-L2738】
 - Surface near-miss helper outputs in the dashboard for unmatched triage.【F:js/features.js†L1708-L1760】

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ _Last updated: 2025-09-24_
 | ✅ | Request log tools | `fetchAndRenderRequests`, `renderRequestCard`, and `clearRequests` drive the list, filtering hooks, and cleanup actions exposed on the Request Log page.【F:js/features.js†L1102-L1296】【F:index.html†L144-L238】 |
 | ✅ | Scenario controls | `loadScenarios`, `setScenarioState`, and `resetAllScenarios` call the Admin API, render available states, and refresh after changes.【F:js/features.js†L1488-L1556】【F:index.html†L240-L322】 |
 | ⚠️ | Cache service | `refreshImockCache`, `regenerateImockCache`, and the scheduled validation rebuild WireMock’s cache mapping and reset optimistic queues, but the flow still relies on live endpoints for full verification.【F:js/features.js†L1988-L2107】【F:js/features.js†L2584-L2662】 |
-| ⚠️ | Recording workflow | `startRecording`, `stopRecording`, and `takeRecordingSnapshot` successfully call the recording endpoints, yet `recording-url`, filters, and `recordings-list` in the UI remain unpopulated placeholders.【F:js/features.js†L1624-L1704】【F:index.html†L324-L413】 |
+| ✅ | Recording workflow | `initializeRecordingForm`, `startRecording`, `stopRecording`, `takeRecordingSnapshot`, and `downloadRecordingResults` parse the OpenAPI fields (body matchers, extract thresholds, snapshot IDs), persist preferences, surface recorder status, and stream captured mappings with inline export controls.【F:js/features.js†L1599-L2219】【F:index.html†L333-L414】 |
 | ⚠️ | Auto-refresh | Settings capture `auto-refresh` preferences, but no interval is started, so datasets refresh only on manual actions or cache rebuilds.【F:js/main.js†L250-L344】 |
 | 🚧 | Demo mode | `loadMockData` only raises an informational toast; it does not populate demo mappings or requests.【F:js/features.js†L2728-L2738】 |
 | 🚧 | Import/export buttons | The Import/Export page wires buttons to `exportMappings`, `exportRequests`, `importMappings`, and `importAndReplace`, yet these functions are undefined and trigger errors when clicked.【F:index.html†L120-L211】【F:js/features.js†L2686-L2727】 |
@@ -55,11 +55,11 @@ _Last updated: 2025-09-24_
 | `POST /__admin/requests/count` / `POST /__admin/requests/find` | Helper functions exist for analytics, but no UI surfaces the results yet.【F:js/features.js†L1558-L1622】 |
 | `GET /__admin/requests/unmatched` & near-miss endpoints | Helper functions implemented without UI glue; intended for future unmatched analysis tooling.【F:js/features.js†L1708-L1760】 |
 | `GET /__admin/scenarios` / `POST /__admin/scenarios/reset` / `PUT /__admin/scenarios/set-state` | Fully wired to the Scenarios page actions and inline buttons.【F:js/features.js†L1488-L1556】【F:index.html†L240-L322】 |
-| Recording endpoints (`/recordings/start`, `/stop`, `/status`, `/snapshot`) | Helpers issue the correct calls and surface notifications, but the Recording tab does not yet use the returned payloads.【F:js/features.js†L1624-L1704】 |
+| Recording endpoints (`/recordings/start`, `/stop`, `/status`, `/snapshot`) | Helpers post full spec-compliant bodies, render results, manage snapshot IDs, and expose a JSON download for generated mappings.【F:js/features.js†L1821-L2219】 |
 | Import/export endpoints (`/mappings/import`, `/requests/remove`, etc.) | Placeholders only; buttons throw because handlers are undefined.【F:index.html†L120-L211】【F:js/features.js†L2686-L2727】 |
 
 ## Known gaps & follow-up items
-- Wire up the Recording tab inputs (`recording-url`, filters) and display results inside `recordings-list` instead of relying on toast notifications alone.【F:index.html†L324-L413】【F:js/features.js†L1624-L1704】
+- Polish snapshot UX by surfacing saved presets, quick ID pickers from the request journal, and richer result metadata (e.g. transformer badges).【F:index.html†L333-L414】【F:js/features.js†L1821-L2219】
 - Implement Import/Export handlers or hide the buttons until the download/upload logic exists to prevent runtime errors.【F:index.html†L120-L211】【F:js/features.js†L2686-L2727】
 - Add a Demo Mode data loader so the dashboard can be exercised without a live WireMock server.【F:js/features.js†L2728-L2738】
 - Surface near-miss helper results in the UI to assist unmatched request triage.【F:js/features.js†L1708-L1760】

--- a/index.html
+++ b/index.html
@@ -339,33 +339,127 @@
                     <div class="card-header">
                         <h3 class="card-title">🎙️ Record API Calls</h3>
                     </div>
-                    <p style="margin-bottom: var(--space-4); color: var(--text-secondary);">Configure recording settings to capture real API calls and generate mappings automatically.</p>
-                    
+                    <p style="margin-bottom: var(--space-4); color: var(--text-secondary);">Configure recording settings to capture upstream traffic and generate WireMock stub mappings automatically.</p>
+
                     <div class="form-row">
                         <div class="form-group">
-                            <label class="form-label">Target URL</label>
+                            <label class="form-label">Target Base URL</label>
                             <input type="text" class="form-input" id="record-target-url" placeholder="https://api.example.com">
+                            <small class="form-help">Proxy destination used while live recording is enabled.</small>
+                        </div>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label class="form-label">URL Path Pattern</label>
+                            <input type="text" class="form-input" id="record-url-pattern" placeholder="/api/.*">
+                            <small class="form-help">WireMock request matcher syntax to limit captured traffic.</small>
                         </div>
                         <div class="form-group">
-                            <label class="form-label">Recording Mode</label>
-                            <select class="form-select" id="record-mode">
-                                <option value="record">Record</option>
-                                <option value="snapshot">Snapshot</option>
+                            <label class="form-label">HTTP Method</label>
+                            <select class="form-select" id="record-http-method">
+                                <option value="ANY">Any</option>
+                                <option value="GET">GET</option>
+                                <option value="POST">POST</option>
+                                <option value="PUT">PUT</option>
+                                <option value="DELETE">DELETE</option>
+                                <option value="PATCH">PATCH</option>
+                                <option value="HEAD">HEAD</option>
+                                <option value="OPTIONS">OPTIONS</option>
                             </select>
                         </div>
+                        <div class="form-group">
+                            <label class="form-label">Output Format</label>
+                            <select class="form-select" id="record-output-format">
+                                <option value="FULL">Full mappings</option>
+                                <option value="IDS">Mapping IDs only</option>
+                            </select>
+                            <small class="form-help">Set to <code>IDS</code> for <code>/recordings/snapshot</code> when only IDs are required.</small>
+                        </div>
                     </div>
-                    
-                    <div style="display: flex; gap: var(--space-3); margin-top: var(--space-4);">
-                        <button class="btn btn-success" onclick="startRecording()">▶️ Start Recording</button>
-                        <button class="btn btn-danger" onclick="stopRecording()">⏹️ Stop Recording</button>
-                        <button class="btn btn-secondary" onclick="clearRecordings()">🗑️ Clear Recordings</button>
+
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label class="form-label">Capture Headers</label>
+                            <input type="text" class="form-input" id="record-capture-headers" placeholder="Accept, Content-Type: ci">
+                            <small class="form-help">Comma separated list. Append <code>:ci</code> for case-insensitive capture.</small>
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Transformers</label>
+                            <input type="text" class="form-input" id="record-transformers" placeholder="response-template, add-headers">
+                            <small class="form-help">Comma separated names applied to generated stubs.</small>
+                        </div>
                     </div>
-                    
-                    <div id="recording-status" style="margin-top: var(--space-4);"></div>
+
+                    <div class="form-row recording-advanced">
+                        <div class="form-group">
+                            <label class="form-label">Request Body Pattern (JSON)</label>
+                            <textarea class="form-input" id="record-body-pattern" rows="4" placeholder='{"matchesJsonPath": "$.orderId"}'></textarea>
+                            <small class="form-help">Optional WireMock request matcher to further limit recorded requests.</small>
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Transformer Parameters (JSON)</label>
+                            <textarea class="form-input" id="record-transformer-params" rows="4" placeholder='{"response-template": {"name": "value"}}'></textarea>
+                            <small class="form-help">Pass custom parameters to configured transformers.</small>
+                        </div>
+                    </div>
+
+                    <div class="form-row recording-advanced">
+                        <div class="form-group">
+                            <label class="form-label">Extract Body Criteria</label>
+                            <div class="threshold-inputs">
+                                <input type="number" class="form-input" id="record-extract-text" placeholder="Text threshold (bytes)">
+                                <input type="number" class="form-input" id="record-extract-binary" placeholder="Binary threshold (bytes)">
+                            </div>
+                            <small class="form-help">Bodies larger than the threshold will be moved to files for readability.</small>
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Snapshot Request IDs</label>
+                            <textarea class="form-input" id="record-snapshot-ids" rows="3" placeholder="40a93c4a-d378-4e07-8321-6158d5dbcb29"></textarea>
+                            <small class="form-help">Comma or newline separated list for <code>/recordings/snapshot</code>.</small>
+                        </div>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label class="form-label">Recording Options</label>
+                            <div class="recording-options">
+                                <label class="form-checkbox">
+                                    <input type="checkbox" id="record-persist" checked>
+                                    Persist generated stubs
+                                </label>
+                                <label class="form-checkbox">
+                                    <input type="checkbox" id="record-repeats-as-scenarios" checked>
+                                    Track repeats as scenarios
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="recording-actions">
+                        <button class="btn btn-success" id="start-recording-btn" onclick="startRecording()">▶️ Start Recording</button>
+                        <button class="btn btn-danger" id="stop-recording-btn" onclick="stopRecording()">⏹️ Stop Recording</button>
+                        <button class="btn btn-secondary" type="button" id="snapshot-recording-btn" onclick="takeRecordingSnapshot()">📸 Snapshot</button>
+                        <button class="btn btn-secondary" type="button" onclick="clearRecordings()">🗑️ Clear Results</button>
+                        <button class="btn btn-secondary" type="button" id="recording-export" onclick="downloadRecordingResults()">⬇️ Download JSON</button>
+                    </div>
+                    <div class="recording-status-panel" id="recording-status">
+                        <div class="recording-status-summary">
+                            <span class="status-dot" id="recording-indicator"></span>
+                            <div>
+                                <div class="recording-status-text" id="recording-status-text">Recorder idle</div>
+                                <div class="recording-status-meta">
+                                    <span id="recording-target">No target configured</span>
+                                    <span id="recording-count">0 mappings captured</span>
+                                </div>
+                            </div>
+                        </div>
+                        <button class="btn btn-secondary btn-compact" type="button" onclick="refreshRecordingStatus()">↻ Refresh status</button>
+                    </div>
                 </div>
-                
-                <div id="recordings-list" style="margin-top: var(--space-6);">
-                    <!-- Recorded mappings will appear here -->
+
+                <div id="recordings-list" class="recordings-list">
+                    <div class="empty-state">Recording results will appear here after stopping a session or taking a snapshot.</div>
                 </div>
             </div>
             

--- a/js/core.js
+++ b/js/core.js
@@ -98,19 +98,32 @@ window.SELECTORS = {
     // Buttons
     BUTTONS: {
         ADD_MAPPING: 'add-mapping-btn',
-        START_RECORDING: 'start-recording-btn'
+        START_RECORDING: 'start-recording-btn',
+        STOP_RECORDING: 'stop-recording-btn',
+        SNAPSHOT_RECORDING: 'snapshot-recording-btn'
     },
 
     // Recording
     RECORDING: {
-        URL: 'recording-url',
-        CAPTURE_HEADERS: 'capture-headers',
-        CAPTURE_BODY: 'capture-body',
-        URL_FILTER: 'url-filter',
+        TARGET_URL: 'record-target-url',
+        URL_PATTERN: 'record-url-pattern',
+        METHOD: 'record-http-method',
+        CAPTURE_HEADERS: 'record-capture-headers',
+        BODY_PATTERN: 'record-body-pattern',
+        EXTRACT_TEXT: 'record-extract-text',
+        EXTRACT_BINARY: 'record-extract-binary',
+        TRANSFORMERS: 'record-transformers',
+        TRANSFORMER_PARAMS: 'record-transformer-params',
+        SNAPSHOT_IDS: 'record-snapshot-ids',
+        OUTPUT_FORMAT: 'record-output-format',
+        PERSIST: 'record-persist',
+        REPEATS: 'record-repeats-as-scenarios',
         INDICATOR: 'recording-indicator',
+        STATUS_TEXT: 'recording-status-text',
         TARGET: 'recording-target',
         COUNT: 'recording-count',
-        STOP_BTN: 'stop-recording-btn'
+        LIST: 'recordings-list',
+        EXPORT: 'recording-export'
     },
 
     // Settings

--- a/js/features.js
+++ b/js/features.js
@@ -12,6 +12,7 @@ window.originalMappings = []; // Complete mapping list from the server
 window.allMappings = []; // Currently displayed mappings (may be filtered)
 window.originalRequests = []; // Complete request list from the server
 window.allRequests = []; // Currently displayed request list (may be filtered)
+window.recordingsHistory = window.recordingsHistory || []; // Recent recording results for UI summaries
 
 // Reliable deletion tracking system
 window.pendingDeletedIds = new Set(); // Track items pending deletion to prevent cache flicker
@@ -1622,104 +1623,772 @@ window.getUnmatchedRequests = async () => {
     }
 };
 
-// --- UPDATED RECORDING HELPERS ---
+// --- RECORDING HELPERS ---
 
-// Start recording
+const RECORDING_STORAGE_KEY = 'wiremock-recording-config';
+
+const getRecordingElement = (id) => {
+    if (typeof document === 'undefined' || !id) return null;
+    try {
+        return document.getElementById(id);
+    } catch (error) {
+        console.debug('recording:getElement fallback', id, error);
+        return null;
+    }
+};
+
+const parseCaptureHeaders = (raw = '') => {
+    return raw
+        .split(',')
+        .map((token) => token.trim())
+        .filter(Boolean)
+        .reduce((acc, token) => {
+            const [name, flag] = token.split(':').map((part) => part.trim());
+            if (!name) return acc;
+            acc[name] = flag && flag.toLowerCase() === 'ci' ? { caseInsensitive: true } : {};
+            return acc;
+        }, {});
+};
+
+const parseJsonField = (raw, label, errors = []) => {
+    if (!raw || !raw.trim()) return null;
+    try {
+        return JSON.parse(raw);
+    } catch (error) {
+        const message = `${label} must be valid JSON.`;
+        errors.push(message);
+        console.error(`recording:${label} parse error`, error);
+        return null;
+    }
+};
+
+const parseNumericField = (raw, label, errors = []) => {
+    if (!raw || !raw.trim()) return undefined;
+    const value = Number(raw);
+    if (!Number.isFinite(value) || value < 0) {
+        const message = `${label} must be a non-negative number.`;
+        errors.push(message);
+        return undefined;
+    }
+    return value;
+};
+
+const parseSnapshotIds = (raw = '') => {
+    return raw
+        .split(/\s|,/)
+        .map((token) => token.trim())
+        .filter(Boolean);
+};
+
+const mergeRecordingConfig = (baseConfig = {}, overrides = {}) => {
+    const merged = { ...baseConfig, ...overrides };
+
+    if (baseConfig.filters || overrides.filters) {
+        merged.filters = {
+            ...(baseConfig.filters || {}),
+            ...(overrides.filters || {}),
+        };
+    }
+
+    if (baseConfig.captureHeaders || overrides.captureHeaders) {
+        merged.captureHeaders = {
+            ...(baseConfig.captureHeaders || {}),
+            ...(overrides.captureHeaders || {}),
+        };
+    }
+
+    if (Array.isArray(baseConfig.transformers) || Array.isArray(overrides.transformers)) {
+        const base = Array.isArray(baseConfig.transformers) ? baseConfig.transformers : [];
+        const next = Array.isArray(overrides.transformers) ? overrides.transformers : [];
+        merged.transformers = Array.from(new Set([...base, ...next]));
+    }
+
+    return merged;
+};
+
+const formatRecordingTimestamp = (value) => {
+    if (!value) return '';
+    try {
+        const date = value instanceof Date ? value : new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            return typeof value === 'string' ? value : '';
+        }
+        return date.toLocaleString();
+    } catch (error) {
+        console.debug('recording:timestamp format error', error);
+        return typeof value === 'string' ? value : '';
+    }
+};
+
+const extractRecordedMappings = (payload) => {
+    if (!payload) return [];
+    if (Array.isArray(payload)) return payload;
+    if (Array.isArray(payload.mappings)) return payload.mappings;
+    if (Array.isArray(payload.stubMappings)) return payload.stubMappings;
+    if (Array.isArray(payload.ids)) return payload.ids;
+    if (payload.recordingResult && Array.isArray(payload.recordingResult.mappings)) {
+        return payload.recordingResult.mappings;
+    }
+    if (payload.recordingResult && Array.isArray(payload.recordingResult.ids)) {
+        return payload.recordingResult.ids;
+    }
+    if (payload.result && Array.isArray(payload.result.mappings)) {
+        return payload.result.mappings;
+    }
+    if (payload.result && Array.isArray(payload.result.ids)) {
+        return payload.result.ids;
+    }
+    return [];
+};
+
+const renderRecordingResults = (mappings = [], { mode = 'record', meta = {} } = {}) => {
+    if (typeof document === 'undefined') return;
+    const container = getRecordingElement(SELECTORS.RECORDING.LIST);
+    if (!container) return;
+
+    if (!Array.isArray(mappings) || mappings.length === 0) {
+        container.innerHTML = '<div class="empty-state">No stub mappings were returned. Start a new recording session or take another snapshot to populate this list.</div>';
+        return;
+    }
+
+    const summaryTitle = mode === 'snapshot' ? 'Snapshot captured' : 'Recording stopped';
+    const contextText = mode === 'snapshot'
+        ? 'Mappings were generated from the request journal via /recordings/snapshot.'
+        : 'Live proxying has been stopped and the captured traffic has been converted to stub mappings.';
+    const totalText = `${mappings.length} ${mappings.length === 1 ? 'item' : 'items'}`;
+
+    const metaSummaryRaw = meta && typeof meta === 'object' && Object.keys(meta).length
+        ? JSON.stringify(meta)
+        : '';
+    const metaSummary = metaSummaryRaw
+        ? `<div class="form-help" style="margin-top: var(--space-2);">Meta: ${Utils?.escapeHtml ? Utils.escapeHtml(metaSummaryRaw.slice(0, 200) + (metaSummaryRaw.length > 200 ? '…' : '')) : metaSummaryRaw}</div>`
+        : '';
+
+    const isIdOnly = (meta?.outputFormat || '').toUpperCase?.() === 'IDS'
+        || mappings.every((item) => typeof item === 'string');
+
+    const items = mappings
+        .map((mapping, index) => {
+            if (typeof mapping === 'string') {
+                const escapedId = Utils?.escapeHtml ? Utils.escapeHtml(mapping) : mapping;
+                return `
+                <div class="recording-item">
+                    <div class="recording-item-header">
+                        <div class="recording-item-title">Mapping ID</div>
+                        <div class="recording-item-meta"><span>${escapedId}</span></div>
+                    </div>
+                </div>
+            `;
+            }
+            const name = mapping?.name || mapping?.id || `Mapping ${index + 1}`;
+            const method = mapping?.request?.method || mapping?.request?.method?.value || '';
+            const url = mapping?.request?.url
+                || mapping?.request?.urlPath
+                || mapping?.request?.urlPattern
+                || mapping?.request?.urlPathPattern
+                || '';
+            const status = mapping?.response?.status || mapping?.response?.statusCode;
+            const scenario = mapping?.scenarioName;
+            const recordedAt = mapping?.recordedAt || mapping?.metadata?.recordedAt || mapping?.metadata?.created;
+            const recordedText = recordedAt ? `Recorded ${formatRecordingTimestamp(recordedAt)}` : '';
+            const description = mapping?.description || mapping?.metadata?.description || '';
+
+            const metaParts = [
+                method && url ? `${method} ${url}` : method || url,
+                status ? `Response ${status}` : '',
+                scenario ? `Scenario: ${scenario}` : '',
+                recordedText,
+            ].filter(Boolean);
+
+            const metaHtml = metaParts.length
+                ? metaParts
+                    .map((part) => `<span>${Utils?.escapeHtml ? Utils.escapeHtml(part) : part}</span>`)
+                    .join('')
+                : `<span>${Utils?.escapeHtml ? Utils.escapeHtml(totalText) : totalText}</span>`;
+
+            const bodyHtml = description
+                ? `<div class="recording-item-body">${Utils?.escapeHtml ? Utils.escapeHtml(description) : description}</div>`
+                : '';
+
+            return `
+                <div class="recording-item">
+                    <div class="recording-item-header">
+                        <div class="recording-item-title">${Utils?.escapeHtml ? Utils.escapeHtml(name) : name}</div>
+                        <div class="recording-item-meta">${metaHtml}</div>
+                    </div>
+                    ${bodyHtml}
+                </div>
+            `;
+        })
+        .join('');
+
+    const formatHint = isIdOnly
+        ? '<p class="form-help" style="margin-top: var(--space-2);">The snapshot was requested with <code>outputFormat: \"IDS\"</code>; download the JSON to retrieve the stub IDs.</p>'
+        : '';
+
+    container.innerHTML = `
+        <div class="recording-results-card">
+            <div class="recording-results-header">
+                <div>
+                    <h4>${summaryTitle}</h4>
+                    <p class="form-help" style="margin-top: var(--space-2);">${contextText}</p>
+                    ${metaSummary}
+                    ${formatHint}
+                </div>
+                <span class="recording-badge">${Utils?.escapeHtml ? Utils.escapeHtml(totalText) : totalText}</span>
+            </div>
+            ${items}
+        </div>
+    `;
+};
+
+const updateRecordingStatusUI = (status = {}) => {
+    if (typeof document === 'undefined') return;
+
+    const indicator = getRecordingElement(SELECTORS.RECORDING.INDICATOR);
+    const statusTextEl = getRecordingElement(SELECTORS.RECORDING.STATUS_TEXT);
+    const targetEl = getRecordingElement(SELECTORS.RECORDING.TARGET);
+    const countEl = getRecordingElement(SELECTORS.RECORDING.COUNT);
+
+    const normalizedStatus = typeof status === 'string'
+        ? status
+        : status.status || status.state || status.recordingStatus || '';
+    const target = status.targetBaseUrl
+        || status.targetUrl
+        || status.target
+        || status?.recordingSpec?.targetBaseUrl
+        || '';
+    const count = typeof status.count === 'number'
+        ? status.count
+        : Array.isArray(status.mappings)
+            ? status.mappings.length
+            : typeof window.recordedCount === 'number'
+                ? window.recordedCount
+                : 0;
+    const isRecording = normalizedStatus && normalizedStatus.toLowerCase() === 'recording';
+
+    window.isRecording = Boolean(isRecording);
+
+    if (indicator) {
+        indicator.classList.remove('recording-active', 'recording-idle');
+        indicator.classList.add(isRecording ? 'recording-active' : 'recording-idle');
+    }
+
+    if (statusTextEl) {
+        if (!normalizedStatus) {
+            statusTextEl.textContent = 'Recorder idle';
+        } else {
+            statusTextEl.textContent = isRecording ? 'Recording in progress' : `Recorder ${normalizedStatus.toLowerCase()}`;
+        }
+    }
+
+    if (targetEl) {
+        targetEl.textContent = target ? `Target: ${target}` : 'No target configured';
+    }
+
+    if (countEl) {
+        countEl.textContent = `${count} ${count === 1 ? 'mapping' : 'mappings'} captured`;
+    }
+
+    const startButtonId = SELECTORS.BUTTONS?.START_RECORDING;
+    if (startButtonId) {
+        const startButton = document.getElementById(startButtonId);
+        if (startButton) startButton.disabled = isRecording;
+    }
+
+    const stopButtonId = SELECTORS.BUTTONS?.STOP_RECORDING;
+    if (stopButtonId) {
+        const stopButton = document.getElementById(stopButtonId);
+        if (stopButton) stopButton.disabled = !isRecording;
+    }
+
+    const snapshotButtonId = SELECTORS.BUTTONS?.SNAPSHOT_RECORDING;
+    if (snapshotButtonId) {
+        const snapshotButton = document.getElementById(snapshotButtonId);
+        if (snapshotButton) snapshotButton.disabled = isRecording;
+    }
+
+    const exportButton = getRecordingElement(SELECTORS.RECORDING.EXPORT);
+    if (exportButton) {
+        exportButton.disabled = !window.lastRecordingResult;
+    }
+};
+
+const readRecordingForm = (mode = 'record') => {
+    if (typeof document === 'undefined') {
+        return { config: {}, mode, errors: [] };
+    }
+
+    const getValue = (id) => getRecordingElement(id)?.value ?? '';
+    const getChecked = (id, fallback = false) => {
+        const el = getRecordingElement(id);
+        return typeof el?.checked === 'boolean' ? el.checked : fallback;
+    };
+
+    const errors = [];
+
+    const config = {};
+    const targetUrl = getValue(SELECTORS.RECORDING.TARGET_URL).trim();
+    if (targetUrl) {
+        config.targetBaseUrl = targetUrl;
+    }
+
+    const filters = {};
+    const urlPattern = getValue(SELECTORS.RECORDING.URL_PATTERN).trim();
+    if (urlPattern) {
+        filters.urlPathPattern = urlPattern;
+    }
+    const method = getValue(SELECTORS.RECORDING.METHOD);
+    if (method && method !== 'ANY') {
+        filters.method = method;
+    }
+    if (Object.keys(filters).length) {
+        config.filters = filters;
+    }
+
+    const captureHeadersRaw = getValue(SELECTORS.RECORDING.CAPTURE_HEADERS);
+    const captureHeaders = parseCaptureHeaders(captureHeadersRaw);
+    if (Object.keys(captureHeaders).length) {
+        config.captureHeaders = captureHeaders;
+    }
+
+    const requestBodyPatternRaw = getValue(SELECTORS.RECORDING.BODY_PATTERN);
+    const requestBodyPattern = parseJsonField(requestBodyPatternRaw, 'Request body pattern', errors);
+    if (requestBodyPatternRaw.trim()) {
+        if (requestBodyPattern) {
+            config.requestBodyPattern = requestBodyPattern;
+        }
+    }
+
+    const transformerParamsRaw = getValue(SELECTORS.RECORDING.TRANSFORMER_PARAMS);
+    const transformerParameters = parseJsonField(transformerParamsRaw, 'Transformer parameters', errors);
+    if (transformerParamsRaw.trim()) {
+        if (transformerParameters) {
+            config.transformerParameters = transformerParameters;
+        }
+    }
+
+    const textThreshold = parseNumericField(getValue(SELECTORS.RECORDING.EXTRACT_TEXT), 'Text body threshold', errors);
+    const binaryThreshold = parseNumericField(getValue(SELECTORS.RECORDING.EXTRACT_BINARY), 'Binary body threshold', errors);
+    if (textThreshold !== undefined || binaryThreshold !== undefined) {
+        config.extractBodyCriteria = {};
+        if (textThreshold !== undefined) config.extractBodyCriteria.textSizeThreshold = textThreshold;
+        if (binaryThreshold !== undefined) config.extractBodyCriteria.binarySizeThreshold = binaryThreshold;
+    }
+
+    const transformersRaw = getValue(SELECTORS.RECORDING.TRANSFORMERS);
+    if (transformersRaw.trim()) {
+        const transformers = transformersRaw
+            .split(',')
+            .map((token) => token.trim())
+            .filter(Boolean);
+        if (transformers.length) {
+            config.transformers = transformers;
+        }
+    }
+
+    if (mode === 'snapshot') {
+        const idsRaw = getValue(SELECTORS.RECORDING.SNAPSHOT_IDS);
+        const ids = parseSnapshotIds(idsRaw);
+        if (ids.length) {
+            config.filters = { ...(config.filters || {}), ids };
+        }
+    }
+
+    const outputFormat = getValue(SELECTORS.RECORDING.OUTPUT_FORMAT) || 'FULL';
+    if (outputFormat) {
+        config.outputFormat = outputFormat;
+    }
+
+    config.persist = getChecked(SELECTORS.RECORDING.PERSIST, true);
+    config.repeatsAsScenarios = getChecked(SELECTORS.RECORDING.REPEATS, true);
+
+    return errors.length ? { config: null, mode, errors } : { config, mode, errors: [] };
+};
+
+const storeRecordingPreferences = (config, mode) => {
+    if (typeof localStorage === 'undefined') return;
+    try {
+        localStorage.setItem(
+            RECORDING_STORAGE_KEY,
+            JSON.stringify({ config, mode, savedAt: Date.now() })
+        );
+    } catch (error) {
+        console.debug('recording:storePreferences error', error);
+    }
+};
+
+const loadRecordingPreferences = () => {
+    if (typeof localStorage === 'undefined') return null;
+    try {
+        const raw = localStorage.getItem(RECORDING_STORAGE_KEY);
+        return raw ? JSON.parse(raw) : null;
+    } catch (error) {
+        console.debug('recording:loadPreferences error', error);
+        return null;
+    }
+};
+
+const populateRecordingForm = (preferences) => {
+    if (typeof document === 'undefined' || !preferences) return;
+    const { config = {}, mode = 'record' } = preferences;
+
+    const setValue = (id, value) => {
+        const el = getRecordingElement(id);
+        if (el && value !== undefined) {
+            el.value = value;
+        }
+    };
+
+    const setChecked = (id, value) => {
+        const el = getRecordingElement(id);
+        if (el && typeof el.checked === 'boolean') {
+            el.checked = Boolean(value);
+        }
+    };
+
+    if (config.targetBaseUrl) setValue(SELECTORS.RECORDING.TARGET_URL, config.targetBaseUrl);
+    if (config.filters?.urlPathPattern) setValue(SELECTORS.RECORDING.URL_PATTERN, config.filters.urlPathPattern);
+    if (config.filters?.method) setValue(SELECTORS.RECORDING.METHOD, config.filters.method);
+    if (Array.isArray(config.filters?.ids)) {
+        setValue(SELECTORS.RECORDING.SNAPSHOT_IDS, config.filters.ids.join('\n'));
+    }
+
+    if (config.captureHeaders) {
+        const captureValue = Object.entries(config.captureHeaders)
+            .map(([name, options]) => `${name}${options?.caseInsensitive ? ':ci' : ''}`)
+            .join(', ');
+        setValue(SELECTORS.RECORDING.CAPTURE_HEADERS, captureValue);
+    }
+
+    if (config.requestBodyPattern) {
+        try {
+            setValue(SELECTORS.RECORDING.BODY_PATTERN, JSON.stringify(config.requestBodyPattern, null, 2));
+        } catch (error) {
+            setValue(SELECTORS.RECORDING.BODY_PATTERN, String(config.requestBodyPattern));
+        }
+    }
+
+    if (config.transformerParameters) {
+        try {
+            setValue(SELECTORS.RECORDING.TRANSFORMER_PARAMS, JSON.stringify(config.transformerParameters, null, 2));
+        } catch (error) {
+            setValue(SELECTORS.RECORDING.TRANSFORMER_PARAMS, String(config.transformerParameters));
+        }
+    }
+
+    if (config.extractBodyCriteria?.textSizeThreshold !== undefined) {
+        setValue(SELECTORS.RECORDING.EXTRACT_TEXT, config.extractBodyCriteria.textSizeThreshold);
+    }
+    if (config.extractBodyCriteria?.binarySizeThreshold !== undefined) {
+        setValue(SELECTORS.RECORDING.EXTRACT_BINARY, config.extractBodyCriteria.binarySizeThreshold);
+    }
+
+    if (Array.isArray(config.transformers) && config.transformers.length) {
+        setValue(SELECTORS.RECORDING.TRANSFORMERS, config.transformers.join(', '));
+    }
+
+    if (config.outputFormat) setValue(SELECTORS.RECORDING.OUTPUT_FORMAT, config.outputFormat);
+    if (config.persist !== undefined) setChecked(SELECTORS.RECORDING.PERSIST, config.persist);
+    if (config.repeatsAsScenarios !== undefined) setChecked(SELECTORS.RECORDING.REPEATS, config.repeatsAsScenarios);
+    window.lastRecordingMode = mode;
+};
+
+const handleRecordingResponse = (payload, { mode = 'record' } = {}) => {
+    const mappings = extractRecordedMappings(payload);
+    const baseMeta = payload?.meta || payload?.recordingResult?.meta || payload?.result?.meta || {};
+    const inferredFormat = baseMeta.outputFormat
+        || payload?.outputFormat
+        || payload?.recordingResult?.outputFormat
+        || payload?.result?.outputFormat
+        || (Array.isArray(payload?.ids)
+            || Array.isArray(payload?.recordingResult?.ids)
+            || Array.isArray(payload?.result?.ids)
+                ? 'IDS'
+                : undefined);
+    const meta = inferredFormat ? { ...baseMeta, outputFormat: inferredFormat } : baseMeta;
+
+    window.recordedCount = mappings.length;
+    window.recordingsHistory = window.recordingsHistory || [];
+    window.recordingsHistory.unshift({
+        timestamp: Date.now(),
+        mode,
+        count: mappings.length,
+        meta,
+        mappings,
+    });
+    window.recordingsHistory = window.recordingsHistory.slice(0, 5);
+
+    window.lastRecordingResult = {
+        raw: payload,
+        mappings,
+        meta,
+        mode,
+    };
+
+    renderRecordingResults(mappings, { mode, meta });
+    updateRecordingStatusUI({ ...(payload && typeof payload === 'object' ? payload : {}), count: mappings.length });
+
+    return mappings;
+};
+
+window.initializeRecordingForm = () => {
+    if (typeof document === 'undefined') return;
+
+    const stored = loadRecordingPreferences();
+    if (stored) {
+        populateRecordingForm(stored);
+    } else {
+        const targetInput = getRecordingElement(SELECTORS.RECORDING.TARGET_URL);
+        if (targetInput && !targetInput.value && window.wiremockBaseUrl) {
+            targetInput.value = window.wiremockBaseUrl.replace(/\/__admin.*$/, '');
+        }
+    }
+
+    const persistFields = [
+        SELECTORS.RECORDING.TARGET_URL,
+        SELECTORS.RECORDING.URL_PATTERN,
+        SELECTORS.RECORDING.METHOD,
+        SELECTORS.RECORDING.CAPTURE_HEADERS,
+        SELECTORS.RECORDING.OUTPUT_FORMAT,
+        SELECTORS.RECORDING.BODY_PATTERN,
+        SELECTORS.RECORDING.TRANSFORMER_PARAMS,
+        SELECTORS.RECORDING.EXTRACT_TEXT,
+        SELECTORS.RECORDING.EXTRACT_BINARY,
+        SELECTORS.RECORDING.TRANSFORMERS,
+    ]
+        .map((id) => getRecordingElement(id))
+        .filter(Boolean);
+
+    persistFields.forEach((input) => {
+        const handler = () => {
+            const { config } = readRecordingForm('record');
+            if (config) {
+                storeRecordingPreferences(config, 'record');
+            }
+        };
+        input.addEventListener('blur', handler);
+        input.addEventListener('change', handler);
+    });
+
+    const snapshotField = getRecordingElement(SELECTORS.RECORDING.SNAPSHOT_IDS);
+    if (snapshotField) {
+        snapshotField.addEventListener('blur', () => {
+            const { config } = readRecordingForm('snapshot');
+            if (config) {
+                storeRecordingPreferences(config, 'snapshot');
+            }
+        });
+    }
+
+    [
+        SELECTORS.RECORDING.PERSIST,
+        SELECTORS.RECORDING.REPEATS,
+    ]
+        .map((id) => getRecordingElement(id))
+        .filter(Boolean)
+        .forEach((checkbox) => {
+            checkbox.addEventListener('change', () => {
+                const { config } = readRecordingForm('record');
+                if (config) {
+                    storeRecordingPreferences(config, 'record');
+                }
+            });
+        });
+
+    void window.refreshRecordingStatus({ silent: true });
+};
+
+window.refreshRecordingStatus = async (options = {}) => {
+    const { silent = false } = typeof options === 'boolean' ? { silent: options } : options;
+    const status = await window.getRecordingStatus();
+
+    if (!silent) {
+        if (status && typeof status === 'object' && status.status) {
+            NotificationManager.info?.(`Recorder status: ${status.status}`);
+        } else {
+            NotificationManager.warning?.('Recorder status unavailable.');
+        }
+    }
+
+    return status;
+};
+
 window.startRecording = async (config = {}) => {
     try {
-        const defaultConfig = {
-            targetBaseUrl: 'https://example.com',
-            filters: {
-                urlPathPatterns: ['.*'],
-                method: 'ANY',
-                headers: {}
-            },
-            captureHeaders: {},
-            requestBodyPattern: {},
-            persist: true,
-            repeatsAsScenarios: false,
-            transformers: ['response-template'],
-            transformerParameters: {}
-        };
-        
-        const recordingConfig = { ...defaultConfig, ...config };
-        
+        const { config: formConfig, errors } = readRecordingForm('record');
+        if (!formConfig) {
+            errors.forEach((message) => NotificationManager.error?.(message));
+            return [];
+        }
+
+        const recordingConfig = mergeRecordingConfig(formConfig, config);
+
+        storeRecordingPreferences(recordingConfig, 'record');
+        window.lastRecordingMode = 'record';
+
+        if (!recordingConfig.targetBaseUrl) {
+            NotificationManager.warning?.('Please provide a target URL before starting recording.');
+            return [];
+        }
+
         await apiFetch(ENDPOINTS.RECORDINGS_START, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(recordingConfig)
+            body: JSON.stringify(recordingConfig),
         });
-        
-        NotificationManager.success('Recording started!');
+
+        NotificationManager.success?.('Recording started. Incoming traffic will be proxied and captured.');
         window.isRecording = true;
-        
-        // Refresh the UI
-        const indicator = document.getElementById(SELECTORS.RECORDING.INDICATOR);
-        if (indicator) indicator.style.display = 'block';
-        
+        updateRecordingStatusUI({ status: 'Recording', targetBaseUrl: recordingConfig.targetBaseUrl });
+        void window.refreshRecordingStatus({ silent: true });
+
+        return [];
     } catch (error) {
         console.error('Start recording error:', error);
-        NotificationManager.error(`Failed to start recording: ${error.message}`);
+        NotificationManager.error?.(`Failed to start recording: ${error?.message || error}`);
+        return [];
     }
 };
 
-// Stop recording
 window.stopRecording = async () => {
     try {
         const response = await apiFetch(ENDPOINTS.RECORDINGS_STOP, {
-            method: 'POST'
+            method: 'POST',
         });
-        
+
         window.isRecording = false;
-        window.recordedCount = 0;
-        
-        // Refresh the UI
-        const indicator = document.getElementById(SELECTORS.RECORDING.INDICATOR);
-        if (indicator) indicator.style.display = 'none';
-        
-        const count = response.mappings ? response.mappings.length : 0;
-        NotificationManager.success(`Recording stopped! Captured ${count} mappings`);
-        
-        // Refresh the mappings list
-        await fetchAndRenderMappings();
-        
-        return response.mappings || [];
+
+        const mappings = handleRecordingResponse(typeof response === 'object' ? response : {}, { mode: 'record' });
+        const count = mappings.length;
+        NotificationManager.success?.(count
+            ? `Recording stopped. Captured ${count} ${count === 1 ? 'mapping' : 'mappings'}.`
+            : 'Recording stopped with no new mappings.');
+
+        if (typeof fetchAndRenderMappings === 'function') {
+            await fetchAndRenderMappings();
+        }
+
+        updateRecordingStatusUI({ status: 'Stopped', count });
+
+        return mappings;
     } catch (error) {
         console.error('Stop recording error:', error);
-        NotificationManager.error(`Failed to stop recording: ${error.message}`);
+        NotificationManager.error?.(`Failed to stop recording: ${error?.message || error}`);
         return [];
     }
 };
 
-// Get recording status
 window.getRecordingStatus = async () => {
     try {
         const response = await apiFetch(ENDPOINTS.RECORDINGS_STATUS);
-        return response.status || 'Unknown';
+        if (response && typeof response === 'object') {
+            updateRecordingStatusUI(response);
+            return response;
+        }
+
+        updateRecordingStatusUI({ status: typeof response === 'string' ? response : 'Unknown' });
+        return response;
     } catch (error) {
         console.error('Recording status error:', error);
-        return 'Unknown';
+        updateRecordingStatusUI({ status: 'Unknown' });
+        return null;
     }
 };
 
-// Create a recording snapshot
 window.takeRecordingSnapshot = async (config = {}) => {
     try {
+        const { config: formConfig, errors } = readRecordingForm('snapshot');
+        if (!formConfig) {
+            errors.forEach((message) => NotificationManager.error?.(message));
+            return [];
+        }
+
+        const snapshotConfig = mergeRecordingConfig(formConfig, config);
+
+        storeRecordingPreferences(snapshotConfig, 'snapshot');
+        window.lastRecordingMode = 'snapshot';
+
         const response = await apiFetch(ENDPOINTS.RECORDINGS_SNAPSHOT, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(config)
+            body: JSON.stringify(snapshotConfig),
         });
-        
-        const count = response.mappings ? response.mappings.length : 0;
-        NotificationManager.success(`Snapshot created! Captured ${count} mappings`);
-        
-        return response.mappings || [];
+
+        const mappings = handleRecordingResponse(typeof response === 'object' ? response : {}, { mode: 'snapshot' });
+        const count = mappings.length;
+        NotificationManager.success?.(count
+            ? `Snapshot captured ${count} ${count === 1 ? 'mapping' : 'mappings'}.`
+            : 'Snapshot completed with no new mappings.');
+
+        if (count && typeof fetchAndRenderMappings === 'function') {
+            await fetchAndRenderMappings();
+        }
+
+        return mappings;
     } catch (error) {
         console.error('Recording snapshot error:', error);
-        NotificationManager.error(`Snapshot failed: ${error.message}`);
+        NotificationManager.error?.(`Snapshot failed: ${error?.message || error}`);
         return [];
     }
+};
+
+window.clearRecordings = () => {
+    window.recordedCount = 0;
+    window.lastRecordingResult = null;
+    window.recordingsHistory = window.recordingsHistory || [];
+    window.recordingsHistory.unshift({ timestamp: Date.now(), mode: 'clear', count: 0, mappings: [] });
+
+    if (typeof document !== 'undefined') {
+        const container = getRecordingElement(SELECTORS.RECORDING.LIST);
+        if (container) {
+            container.innerHTML = '<div class="empty-state">Recording results have been cleared. Start a new session to capture fresh mappings.</div>';
+        }
+        const exportButton = getRecordingElement(SELECTORS.RECORDING.EXPORT);
+        if (exportButton) {
+            exportButton.disabled = true;
+        }
+    }
+
+    updateRecordingStatusUI({ count: 0, status: window.isRecording ? 'Recording' : 'Stopped' });
+    NotificationManager.info?.('Recording results cleared from the dashboard.');
+};
+
+window.downloadRecordingResults = () => {
+    if (!window.lastRecordingResult) {
+        NotificationManager.info?.('No recording results available to download yet.');
+        return null;
+    }
+
+    const payload = window.lastRecordingResult.raw ?? window.lastRecordingResult.mappings;
+    const serialized = typeof payload === 'string'
+        ? payload
+        : JSON.stringify(payload, null, 2);
+
+    if (typeof document === 'undefined' || typeof Blob === 'undefined' || typeof URL === 'undefined') {
+        return serialized;
+    }
+
+    try {
+        const blob = new Blob([serialized], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+        link.href = url;
+        link.download = `wiremock-recording-${timestamp}.json`;
+        document.body.appendChild(link);
+        if (typeof link.click === 'function') {
+            link.click();
+        }
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+        NotificationManager.success?.('Recording payload downloaded.');
+    } catch (error) {
+        console.error('Recording download error:', error);
+        NotificationManager.error?.(`Failed to download recording: ${error?.message || error}`);
+    }
+
+    return serialized;
 };
 
 // --- NEAR MISSES FUNCTIONS ---

--- a/js/main.js
+++ b/js/main.js
@@ -226,6 +226,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     await new Promise(resolve => requestAnimationFrame(resolve));
     loadSettings();
     loadConnectionSettings();
+    if (typeof window.initializeRecordingForm === 'function') {
+        window.initializeRecordingForm();
+    }
     // Ensure settings are loaded before any operations
     console.log('🔧 [main.js] Page loaded, settings initialized, ready for user interaction');
 });

--- a/styles/components.css
+++ b/styles/components.css
@@ -161,6 +161,180 @@
     font-style: italic;
 }
 
+.form-checkbox {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--font-size-sm);
+    color: var(--text-secondary);
+}
+
+.recording-options {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+
+.recording-advanced {
+    gap: var(--space-4);
+}
+
+.recording-advanced .form-group {
+    flex: 1;
+}
+
+.recording-advanced textarea {
+    min-height: 7rem;
+    font-family: var(--font-mono);
+}
+
+.threshold-inputs {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: var(--space-3);
+    margin-top: var(--space-2);
+}
+
+.recording-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    margin-top: var(--space-4);
+    align-items: center;
+}
+
+.btn-compact {
+    padding: var(--space-2) var(--space-3);
+    font-size: var(--font-size-sm);
+}
+
+.recording-actions .btn {
+    flex: 0 0 auto;
+}
+
+#recording-export {
+    margin-left: auto;
+}
+
+.recording-status-panel {
+    margin-top: var(--space-4);
+    padding: var(--space-4);
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-primary);
+    border-radius: var(--radius-xl);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    flex-wrap: wrap;
+}
+
+.recording-status-summary {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+}
+
+.recording-status-text {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.recording-status-meta {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    font-size: var(--font-size-sm);
+    color: var(--text-secondary);
+}
+
+.recordings-list {
+    margin-top: var(--space-6);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+}
+
+.recording-results-card {
+    padding: var(--space-4);
+    background: var(--bg-primary);
+    border-radius: var(--radius-xl);
+    border: 1px solid var(--border-primary);
+    box-shadow: var(--shadow-sm);
+}
+
+.recording-results-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-4);
+    flex-wrap: wrap;
+    margin-bottom: var(--space-4);
+}
+
+.recording-results-header h4 {
+    margin: 0;
+    font-size: var(--font-size-lg);
+}
+
+.recording-badge {
+    background: var(--primary-100);
+    color: var(--primary-700);
+    border-radius: var(--radius-md);
+    padding: var(--space-2) var(--space-3);
+    font-weight: 600;
+}
+
+[data-theme="dark"] .recording-badge {
+    background: rgba(var(--primary-400-rgb), 0.2);
+    color: var(--text-inverse);
+}
+
+.recording-item {
+    border-top: 1px solid var(--border-primary);
+    padding-top: var(--space-3);
+    margin-top: var(--space-3);
+}
+
+.recording-item:first-of-type {
+    border-top: none;
+    padding-top: 0;
+    margin-top: 0;
+}
+
+.recording-item-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+}
+
+.recording-item-title {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.recording-item-meta {
+    display: flex;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+    font-size: var(--font-size-sm);
+    color: var(--text-secondary);
+}
+
+.recording-item-meta span {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+}
+
+.recording-item-body {
+    margin-top: var(--space-2);
+    font-size: var(--font-size-sm);
+    color: var(--text-secondary);
+}
+
 /* ===== CARDS ===== */
 .card {
     background: var(--bg-primary);

--- a/styles/main.css
+++ b/styles/main.css
@@ -185,6 +185,16 @@ body {
     animation: none;
 }
 
+.status-dot.recording-active {
+    background: var(--success);
+    animation: pulse 1.5s infinite;
+}
+
+.status-dot.recording-idle {
+    background: var(--border-accent);
+    animation: none;
+}
+
 .theme-toggle {
     background: none;
     border: 1px solid var(--border-primary);

--- a/tests/recording-workflow.spec.js
+++ b/tests/recording-workflow.spec.js
@@ -1,0 +1,288 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const sandbox = {
+    console,
+    setTimeout,
+    clearTimeout,
+    setInterval: () => 0,
+    clearInterval: () => {},
+    performance: { now: () => 0 },
+    AbortController,
+};
+
+sandbox.window = sandbox;
+sandbox.location = { origin: 'http://localhost' };
+sandbox.matchMedia = () => ({ matches: false, addListener() {}, removeListener() {} });
+sandbox.navigator = { clipboard: { writeText: async () => {} } };
+sandbox.addEventListener = () => {};
+sandbox.removeEventListener = () => {};
+
+const domElementStub = () => ({
+    style: {},
+    classList: { add() {}, remove() {}, contains() { return false; } },
+    value: '',
+    innerHTML: '',
+    dataset: {},
+    addEventListener() {},
+    removeEventListener() {},
+    setAttribute() {},
+    getAttribute() { return null; },
+});
+
+const elements = Object.create(null);
+const bodyStub = domElementStub();
+bodyStub.setAttribute = (name, value) => { bodyStub[`__attr_${name}`] = value; };
+bodyStub.getAttribute = (name) => bodyStub[`__attr_${name}`] || null;
+
+sandbox.document = {
+    readyState: 'complete',
+    addEventListener() {},
+    removeEventListener() {},
+    getElementById(id) {
+        if (!elements[id]) {
+            elements[id] = domElementStub();
+        }
+        return elements[id];
+    },
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+    createElement: domElementStub,
+    body: bodyStub,
+};
+
+sandbox.localStorage = {
+    _data: Object.create(null),
+    getItem(key) { return Object.prototype.hasOwnProperty.call(this._data, key) ? this._data[key] : null; },
+    setItem(key, value) { this._data[key] = String(value); },
+    removeItem(key) { delete this._data[key]; },
+    clear() { this._data = Object.create(null); },
+};
+
+const notifications = [];
+
+sandbox.NotificationManager = {
+    success(message) { notifications.push({ type: 'success', message }); },
+    error(message) { notifications.push({ type: 'error', message }); },
+    warning(message) { notifications.push({ type: 'warning', message }); },
+    info(message) { notifications.push({ type: 'info', message }); },
+    show() {},
+    TYPES: { INFO: 'info', WARNING: 'warning', ERROR: 'error' },
+};
+
+sandbox.FilterManager = {
+    applyMappingFilters() {},
+    applyRequestFilters() {},
+};
+
+sandbox.UIComponents = {
+    toggleFullContent() {},
+    toggleDetails() {},
+    createPreviewSection() { return ''; },
+};
+
+sandbox.Utils = {
+    escapeHtml(value) { return String(value ?? ''); },
+};
+
+sandbox.updateDataSourceIndicator = () => {};
+sandbox.updateMappingsCounter = () => {};
+sandbox.updateRequestsCounter = () => {};
+sandbox.invalidateElementCache = () => {};
+sandbox.TabManager = { refresh: async () => {} };
+
+const fetchCalls = [];
+
+const createJsonResponse = (data) => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: { get: () => 'application/json' },
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+});
+
+sandbox.__mockFetch = async (url, options = {}) => {
+    fetchCalls.push({ url, options });
+    return createJsonResponse({});
+};
+
+sandbox.fetch = async (url, options = {}) => sandbox.__mockFetch(url, options);
+
+const context = vm.createContext(sandbox);
+
+for (const script of ['js/core.js', 'js/features.js']) {
+    const code = fs.readFileSync(path.join(__dirname, '..', script), 'utf8');
+    vm.runInContext(code, context, { filename: script });
+}
+
+context.fetchAndRenderMappings = async () => {};
+context.fetchAndRenderRequests = async () => {};
+context.notifications = notifications;
+context.fetchCalls = fetchCalls;
+context.wiremockBaseUrl = 'http://localhost:8080/__admin';
+context.localStorage.setItem('wiremock-settings', JSON.stringify({ requestTimeout: 2500 }));
+
+const { SELECTORS } = context;
+
+const tests = [];
+
+const addTest = (name, fn) => {
+    tests.push({ name, fn });
+};
+
+addTest('startRecording posts merged configuration and toggles state', async () => {
+    notifications.length = 0;
+    fetchCalls.length = 0;
+
+    const startBodies = [];
+    let refreshCalled = false;
+
+    context.__mockFetch = async (url, options = {}) => {
+        fetchCalls.push({ url, options });
+        if (!url.endsWith('/recordings/start')) {
+            throw new Error(`Unexpected fetch during startRecording: ${url}`);
+        }
+        startBodies.push(JSON.parse(options.body));
+        return createJsonResponse({});
+    };
+
+    context.refreshRecordingStatus = async (options) => {
+        refreshCalled = true;
+        assert.strictEqual(options && options.silent, true);
+        return { status: 'Recording' };
+    };
+
+    const result = await context.startRecording({
+        targetBaseUrl: 'https://target.example/api',
+        filters: { method: 'POST' },
+        captureHeaders: { 'X-Test': {} },
+        outputFormat: 'FULL',
+    });
+
+    assert.strictEqual(Array.isArray(result), true);
+    assert.strictEqual(result.length, 0);
+    assert.strictEqual(context.isRecording, true);
+    assert.strictEqual(refreshCalled, true);
+    assert.strictEqual(startBodies.length, 1);
+    assert.strictEqual(startBodies[0].targetBaseUrl, 'https://target.example/api');
+    assert.deepStrictEqual(startBodies[0].filters, { method: 'POST' });
+    assert.deepStrictEqual(startBodies[0].captureHeaders, { 'X-Test': {} });
+    assert.strictEqual(startBodies[0].persist, true);
+    assert.strictEqual(startBodies[0].repeatsAsScenarios, true);
+
+    const stored = JSON.parse(context.localStorage.getItem('wiremock-recording-config'));
+    assert.strictEqual(stored.mode, 'record');
+    assert.strictEqual(stored.config.targetBaseUrl, 'https://target.example/api');
+});
+
+addTest('stopRecording returns captured mappings and updates history', async () => {
+    notifications.length = 0;
+    fetchCalls.length = 0;
+
+    const sampleMappings = [
+        { id: '1', name: 'First mapping' },
+        { id: '2', name: 'Second mapping' },
+    ];
+
+    let mappingsRefreshed = false;
+    context.fetchAndRenderMappings = async () => { mappingsRefreshed = true; };
+
+    context.__mockFetch = async (url, options = {}) => {
+        fetchCalls.push({ url, options });
+        if (!url.endsWith('/recordings/stop')) {
+            throw new Error(`Unexpected fetch during stopRecording: ${url}`);
+        }
+        return createJsonResponse({ recordingResult: { mappings: sampleMappings, meta: { source: 'proxy' } } });
+    };
+
+    context.isRecording = true;
+    context.recordingsHistory = [];
+
+    const result = await context.stopRecording();
+
+    assert.strictEqual(Array.isArray(result), true);
+    assert.deepStrictEqual(result.map(({ id, name }) => ({ id, name })), sampleMappings);
+    assert.strictEqual(context.isRecording, false);
+    assert.strictEqual(mappingsRefreshed, true);
+    assert.strictEqual(context.recordingsHistory.length > 0, true);
+    assert.strictEqual(context.recordingsHistory[0].count, sampleMappings.length);
+    assert.strictEqual(context.recordingsHistory[0].mode, 'record');
+
+    const success = notifications.find((n) => n.type === 'success');
+    assert(success && success.message.includes('Captured 2'));
+});
+
+addTest('takeRecordingSnapshot stores snapshot mode and renders mappings', async () => {
+    notifications.length = 0;
+    fetchCalls.length = 0;
+
+    context.document.getElementById(SELECTORS.RECORDING.SNAPSHOT_IDS).value = 'req-1, req-2';
+
+    context.__mockFetch = async (url, options = {}) => {
+        fetchCalls.push({ url, options });
+        if (!url.endsWith('/recordings/snapshot')) {
+            throw new Error(`Unexpected fetch during takeRecordingSnapshot: ${url}`);
+        }
+        const body = JSON.parse(options.body);
+        assert.strictEqual(body.outputFormat, 'FULL');
+        assert.deepStrictEqual(body.filters.ids, ['req-1', 'req-2']);
+        return createJsonResponse({ stubMappings: [{ id: 'snap-1', name: 'Snapshot mapping' }] });
+    };
+
+    const mappings = await context.takeRecordingSnapshot({ targetBaseUrl: 'https://snapshot.example' });
+
+    assert.strictEqual(Array.isArray(mappings), true);
+    assert.strictEqual(mappings.length, 1);
+    assert.strictEqual(mappings[0].id, 'snap-1');
+
+    const stored = JSON.parse(context.localStorage.getItem('wiremock-recording-config'));
+    assert.strictEqual(stored.mode, 'snapshot');
+    assert.strictEqual(stored.config.targetBaseUrl, 'https://snapshot.example');
+
+    const success = notifications.find((n) => n.type === 'success');
+    assert(success && success.message.includes('Snapshot captured 1 mapping'));
+
+    context.document.getElementById(SELECTORS.RECORDING.SNAPSHOT_IDS).value = '';
+});
+
+addTest('downloadRecordingResults returns serialized payload when running headless', async () => {
+    const sampleMappings = [{ id: 'm-1' }];
+    context.lastRecordingResult = { raw: { mappings: sampleMappings }, mappings: sampleMappings, meta: {}, mode: 'record' };
+    const serialized = context.downloadRecordingResults();
+    assert(serialized.includes('m-1'));
+});
+
+addTest('startRecording reports invalid JSON in request body pattern', async () => {
+    notifications.length = 0;
+    fetchCalls.length = 0;
+
+    const bodyField = context.document.getElementById(SELECTORS.RECORDING.BODY_PATTERN);
+    bodyField.value = '{invalid json';
+
+    const result = await context.startRecording({ targetBaseUrl: 'https://target.example' });
+    assert.strictEqual(Array.isArray(result), true);
+    assert.strictEqual(result.length, 0);
+    assert.strictEqual(fetchCalls.length, 0);
+    const error = notifications.find((n) => n.type === 'error' && n.message.includes('Request body pattern must be valid JSON'));
+    assert(error, 'Expected validation error for invalid JSON');
+
+    bodyField.value = '';
+});
+
+const run = async () => {
+    for (const { name, fn } of tests) {
+        try {
+            await fn();
+            console.log(`✔ ${name}`);
+        } catch (error) {
+            console.error(`✖ ${name}`);
+            console.error(error);
+            process.exit(1);
+        }
+    }
+};
+
+run();


### PR DESCRIPTION
## Summary
- replace the recording tab with spec-compliant controls for body matchers, extract thresholds, snapshot IDs, and JSON export status
- harden recording helpers to validate form input, manage recorder status, stream results, and cover snapshot/validation flows in tests
- refresh checklist and docs to reflect the rebuilt recording workflow and follow-up backlog items

## Testing
- node tests/recording-workflow.spec.js
- node tests/cache-workflow.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d59506410083298f48338f746c8935