### PR TITLE
Fix optimistic cache renders preserving source indicator

### DIFF
--- a/js/features/mappings.js
+++ b/js/features/mappings.js
@@ -177,7 +177,7 @@ window.fetchAndRenderMappings = async (mappingsToRender = null, options = {}) =>
         return false;
     }
 
-    let renderSource = 'unknown';
+    let renderSource = null;
 
     try {
         if (mappingsToRender === null) {
@@ -248,7 +248,7 @@ window.fetchAndRenderMappings = async (mappingsToRender = null, options = {}) =>
                                 rebuildMappingIndex(window.originalMappings);
 
                                 // Re-render UI with merged complete data
-                                fetchAndRenderMappings(window.allMappings);
+                                fetchAndRenderMappings(window.allMappings, { source: 'direct' });
                             }
                         } catch (e) {
                             console.warn('🧩 [CACHE] Failed to load fresh data:', e);
@@ -321,12 +321,12 @@ window.fetchAndRenderMappings = async (mappingsToRender = null, options = {}) =>
             // Update data source indicator in UI
             renderSource = dataSource;
         } else {
-            const sourceOverride = options?.source;
+            const sourceOverride = typeof options?.source === 'string' ? options.source : null;
             window.allMappings = Array.isArray(mappingsToRender) ? [...mappingsToRender] : [];
             window.originalMappings = [...window.allMappings];
             refreshMappingTabSnapshot();
             rebuildMappingIndex(window.originalMappings);
-            renderSource = sourceOverride || 'custom';
+            renderSource = sourceOverride;
             if (renderSource === 'demo') {
                 markDemoModeActive('manual-mappings');
             }
@@ -362,14 +362,17 @@ window.fetchAndRenderMappings = async (mappingsToRender = null, options = {}) =>
             const urlB = b.request?.url || b.request?.urlPattern || b.request?.urlPath || '';
             return urlA.localeCompare(urlB);
         });
-        console.log(`📦 Mappings render from: ${renderSource} — ${sortedMappings.length} items`);
+        const logSource = renderSource || 'previous';
+        console.log(`📦 Mappings render from: ${logSource} — ${sortedMappings.length} items`);
         renderList(container, sortedMappings, {
             renderItem: renderMappingMarkup,
             getKey: getMappingRenderKey,
             getSignature: getMappingRenderSignature
         });
         updateMappingsCounter();
-        updateDataSourceIndicator(renderSource);
+        if (renderSource) {
+            updateDataSourceIndicator(renderSource);
+        }
         // Reapply mapping filters if any are active, preserving user's view
         try {
             const hasFilters = (document.getElementById(SELECTORS.MAPPING_FILTERS.METHOD)?.value || '')


### PR DESCRIPTION
## Summary
- ensure optimistic re-renders from cache preserve the current data source indicator instead of forcing "custom"
- tag background refresh renders as coming from the server so the UI reflects the authoritative source

## Testing
- node tests/cache-workflow.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68dd40d8a60883299205c340b3fb5945