### PR TITLE
Improve sidebar toggle icon and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,10 +140,11 @@
             <path d="M15 7l4 5-4 5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
             <path d="M13 5l-2 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
         </symbol>
-        <symbol id="icon-arrows-in" viewBox="0 0 24 24">
-            <path d="M9 8L5 12l4 4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M15 8l4 4-4 4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M14 12h-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        <symbol id="icon-sidebar-collapse" viewBox="0 0 20 20">
+            <path fill="currentColor" d="M6.83496 3.99992C6.38353 4.00411 6.01421 4.0122 5.69824 4.03801C5.31232 4.06954 5.03904 4.12266 4.82227 4.20012L4.62207 4.28606C4.18264 4.50996 3.81498 4.85035 3.55859 5.26848L3.45605 5.45207C3.33013 5.69922 3.25006 6.01354 3.20801 6.52824C3.16533 7.05065 3.16504 7.71885 3.16504 8.66301V11.3271C3.16504 12.2712 3.16533 12.9394 3.20801 13.4618C3.25006 13.9766 3.33013 14.2909 3.45605 14.538L3.55859 14.7216C3.81498 15.1397 4.18266 15.4801 4.62207 15.704L4.82227 15.79C5.03904 15.8674 5.31234 15.9205 5.69824 15.9521C6.01398 15.9779 6.383 15.986 6.83398 15.9902L6.83496 3.99992ZM18.165 11.3271C18.165 12.2493 18.1653 12.9811 18.1172 13.5702C18.0745 14.0924 17.9916 14.5472 17.8125 14.9648L17.7295 15.1415C17.394 15.8 16.8834 16.3511 16.2568 16.7353L15.9814 16.8896C15.5157 17.1268 15.0069 17.2285 14.4102 17.2773C13.821 17.3254 13.0893 17.3251 12.167 17.3251H7.83301C6.91071 17.3251 6.17898 17.3254 5.58984 17.2773C5.06757 17.2346 4.61294 17.1508 4.19531 16.9716L4.01855 16.8896C3.36014 16.5541 2.80898 16.0434 2.4248 15.4169L2.27051 15.1415C2.03328 14.6758 1.93158 14.167 1.88281 13.5702C1.83468 12.9811 1.83496 12.2493 1.83496 11.3271V8.66301C1.83496 7.74072 1.83468 7.00898 1.88281 6.41985C1.93157 5.82309 2.03329 5.31432 2.27051 4.84856L2.4248 4.57317C2.80898 3.94666 3.36012 3.436 4.01855 3.10051L4.19531 3.0175C4.61285 2.83843 5.06771 2.75548 5.58984 2.71281C6.17898 2.66468 6.91071 2.66496 7.83301 2.66496H12.167C13.0893 2.66496 13.821 2.66468 14.4102 2.71281C15.0069 2.76157 15.5157 2.86329 15.9814 3.10051L16.2568 3.25481C16.8833 3.63898 17.394 4.19012 17.7295 4.84856L17.8125 5.02531C17.9916 5.44285 18.0745 5.89771 18.1172 6.41985C18.1653 7.00898 18.165 7.74072 18.165 8.66301V11.3271ZM8.16406 15.995H12.167C13.1112 15.995 13.7794 15.9947 14.3018 15.9521C14.8164 15.91 15.1308 15.8299 15.3779 15.704L15.5615 15.6015C15.9797 15.3451 16.32 14.9774 16.5439 14.538L16.6299 14.3378C16.7074 14.121 16.7605 13.8478 16.792 13.4618C16.8347 12.9394 16.835 12.2712 16.835 11.3271V8.66301C16.835 7.71885 16.8347 7.05065 16.792 6.52824C16.7605 6.14232 16.7073 5.86904 16.6299 5.65227L16.5439 5.45207C16.32 5.01264 15.9796 4.64498 15.5615 4.3886L15.3779 4.28606C15.1308 4.16013 14.8165 4.08006 14.3018 4.03801C13.7794 3.99533 13.1112 3.99504 12.167 3.99504H8.16406C8.16407 3.99667 8.16504 3.99829 8.16504 3.99992L8.16406 15.995Z"/>
+        </symbol>
+        <symbol id="icon-sidebar-expand" viewBox="0 0 20 20">
+            <path fill="currentColor" transform="scale(-1 1) translate(-20 0)" d="M6.83496 3.99992C6.38353 4.00411 6.01421 4.0122 5.69824 4.03801C5.31232 4.06954 5.03904 4.12266 4.82227 4.20012L4.62207 4.28606C4.18264 4.50996 3.81498 4.85035 3.55859 5.26848L3.45605 5.45207C3.33013 5.69922 3.25006 6.01354 3.20801 6.52824C3.16533 7.05065 3.16504 7.71885 3.16504 8.66301V11.3271C3.16504 12.2712 3.16533 12.9394 3.20801 13.4618C3.25006 13.9766 3.33013 14.2909 3.45605 14.538L3.55859 14.7216C3.81498 15.1397 4.18266 15.4801 4.62207 15.704L4.82227 15.79C5.03904 15.8674 5.31234 15.9205 5.69824 15.9521C6.01398 15.9779 6.383 15.986 6.83398 15.9902L6.83496 3.99992ZM18.165 11.3271C18.165 12.2493 18.1653 12.9811 18.1172 13.5702C18.0745 14.0924 17.9916 14.5472 17.8125 14.9648L17.7295 15.1415C17.394 15.8 16.8834 16.3511 16.2568 16.7353L15.9814 16.8896C15.5157 17.1268 15.0069 17.2285 14.4102 17.2773C13.821 17.3254 13.0893 17.3251 12.167 17.3251H7.83301C6.91071 17.3251 6.17898 17.3254 5.58984 17.2773C5.06757 17.2346 4.61294 17.1508 4.19531 16.9716L4.01855 16.8896C3.36014 16.5541 2.80898 16.0434 2.4248 15.4169L2.27051 15.1415C2.03328 14.6758 1.93158 14.167 1.88281 13.5702C1.83468 12.9811 1.83496 12.2493 1.83496 11.3271V8.66301C1.83496 7.74072 1.83468 7.00898 1.88281 6.41985C1.93157 5.82309 2.03329 5.31432 2.27051 4.84856L2.4248 4.57317C2.80898 3.94666 3.36012 3.436 4.01855 3.10051L4.19531 3.0175C4.61285 2.83843 5.06771 2.75548 5.58984 2.71281C6.17898 2.66468 6.91071 2.66496 7.83301 2.66496H12.167C13.0893 2.66496 13.821 2.66468 14.4102 2.71281C15.0069 2.76157 15.5157 2.86329 15.9814 3.10051L16.2568 3.25481C16.8833 3.63898 17.394 4.19012 17.7295 4.84856L17.8125 5.02531C17.9916 5.44285 18.0745 5.89771 18.1172 6.41985C18.1653 7.00898 18.165 7.74072 18.165 8.66301V11.3271ZM8.16406 15.995H12.167C13.1112 15.995 13.7794 15.9947 14.3018 15.9521C14.8164 15.91 15.1308 15.8299 15.3779 15.704L15.5615 15.6015C15.9797 15.3451 16.32 14.9774 16.5439 14.538L16.6299 14.3378C16.7074 14.121 16.7605 13.8478 16.792 13.4618C16.8347 12.9394 16.835 12.2712 16.835 11.3271V8.66301C16.835 7.71885 16.8347 7.05065 16.792 6.52824C16.7605 6.14232 16.7073 5.86904 16.6299 5.65227L16.5439 5.45207C16.32 5.01264 15.9796 4.64498 15.5615 4.3886L15.3779 4.28606C15.1308 4.16013 14.8165 4.08006 14.3018 4.03801C13.7794 3.99533 13.1112 3.99504 12.167 3.99504H8.16406C8.16407 3.99667 8.16504 3.99829 8.16504 3.99992L8.16406 15.995Z"/>
         </symbol>
         <symbol id="icon-minus" viewBox="0 0 24 24">
             <path d="M6 12h12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
@@ -176,29 +177,36 @@
 
     <div class="container">
         <div class="sidebar">
-            <div class="nav-item active" onclick="showPage('mappings', this)">
-                <svg class="icon nav-icon" aria-hidden="true" focusable="false"><use href="#icon-clipboard"></use></svg>
-                <span>Mappings</span>
+            <div class="sidebar-controls">
+                <button class="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Collapse sidebar" aria-expanded="true" title="Collapse sidebar">
+                    <svg class="icon icon-18" aria-hidden="true" focusable="false"><use href="#icon-sidebar-collapse"></use></svg>
+                </button>
             </div>
-            <div class="nav-item" onclick="showPage('requests', this)">
-                <svg class="icon nav-icon" aria-hidden="true" focusable="false"><use href="#icon-inbox"></use></svg>
-                <span>Request Log</span>
-            </div>
-            <div class="nav-item" onclick="showPage('scenarios', this)">
-                <svg class="icon nav-icon" aria-hidden="true" focusable="false"><use href="#icon-masks"></use></svg>
-                <span>Scenarios</span>
-            </div>
-            <div class="nav-item" onclick="showPage('import-export', this)">
-                <svg class="icon nav-icon" aria-hidden="true" focusable="false"><use href="#icon-box"></use></svg>
-                <span>Import/Export</span>
-            </div>
-            <div class="nav-item" onclick="showPage('recording', this)">
-                <svg class="icon nav-icon" aria-hidden="true" focusable="false"><use href="#icon-mic"></use></svg>
-                <span>Recording</span>
-            </div>
-            <div class="nav-item" onclick="showPage('settings', this)">
-                <svg class="icon nav-icon" aria-hidden="true" focusable="false"><use href="#icon-settings"></use></svg>
-                <span>Settings</span>
+            <div class="sidebar-nav">
+                <div class="nav-item active" onclick="showPage('mappings', this)" aria-label="Mappings" title="Mappings">
+                    <svg class="icon nav-icon" aria-hidden="true" focusable="false"><use href="#icon-clipboard"></use></svg>
+                    <span>Mappings</span>
+                </div>
+                <div class="nav-item" onclick="showPage('requests', this)" aria-label="Request Log" title="Request Log">
+                    <svg class="icon nav-icon" aria-hidden="true" focusable="false"><use href="#icon-inbox"></use></svg>
+                    <span>Request Log</span>
+                </div>
+                <div class="nav-item" onclick="showPage('scenarios', this)" aria-label="Scenarios" title="Scenarios">
+                    <svg class="icon nav-icon" aria-hidden="true" focusable="false"><use href="#icon-masks"></use></svg>
+                    <span>Scenarios</span>
+                </div>
+                <div class="nav-item" onclick="showPage('import-export', this)" aria-label="Import and Export" title="Import and Export">
+                    <svg class="icon nav-icon" aria-hidden="true" focusable="false"><use href="#icon-box"></use></svg>
+                    <span>Import/Export</span>
+                </div>
+                <div class="nav-item" onclick="showPage('recording', this)" aria-label="Recording" title="Recording">
+                    <svg class="icon nav-icon" aria-hidden="true" focusable="false"><use href="#icon-mic"></use></svg>
+                    <span>Recording</span>
+                </div>
+                <div class="nav-item" onclick="showPage('settings', this)" aria-label="Settings" title="Settings">
+                    <svg class="icon nav-icon" aria-hidden="true" focusable="false"><use href="#icon-settings"></use></svg>
+                    <span>Settings</span>
+                </div>
             </div>
         </div>
         

--- a/js/main.js
+++ b/js/main.js
@@ -585,10 +585,14 @@ window.applyDefaultsToForm = () => {
 // Load settings when page loads
 document.addEventListener('DOMContentLoaded', async () => {
     await new Promise(resolve => requestAnimationFrame(resolve));
-    
+
+    if (typeof window.initializeSidebarPreference === 'function') {
+        window.initializeSidebarPreference();
+    }
+
     // First apply defaults to empty form fields
     applyDefaultsToForm();
-    
+
     // Then load saved settings (will override defaults if settings exist)
     loadSettings();
     loadConnectionSettings();

--- a/styles/main.css
+++ b/styles/main.css
@@ -334,6 +334,44 @@ body[data-theme="light"] {
     overflow-y: auto;
     box-shadow: var(--shadow-md);
     backdrop-filter: blur(12px);
+    transition: width var(--transition-fast), padding var(--transition-fast);
+}
+
+.sidebar-controls {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: var(--space-4);
+}
+
+.sidebar-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(59, 130, 246, 0.12);
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: background var(--transition-fast), color var(--transition-fast), border var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.sidebar-toggle:hover {
+    background: rgba(59, 130, 246, 0.2);
+    color: var(--text-primary);
+    border-color: rgba(59, 130, 246, 0.35);
+    box-shadow: 0 16px 32px rgba(37, 99, 235, 0.3);
+}
+
+.sidebar-toggle .icon {
+    transition: transform var(--transition-fast);
+}
+
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
 }
 
 .main-content {
@@ -391,6 +429,17 @@ body[data-theme="light"] {
     box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
 }
 
+[data-theme="light"] .sidebar-toggle {
+    background: rgba(59, 130, 246, 0.08);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    color: #1e3a8a;
+}
+
+[data-theme="light"] .sidebar-toggle:hover {
+    background: rgba(59, 130, 246, 0.16);
+    box-shadow: 0 18px 38px rgba(59, 130, 246, 0.18);
+}
+
 [data-theme="light"] .main-content {
     background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(226, 232, 240, 0.88));
     border: 1px solid rgba(148, 163, 184, 0.35);
@@ -428,6 +477,7 @@ body[data-theme="light"] {
 }
 
 .theme-toggle:focus-visible,
+.sidebar-toggle:focus-visible,
 .nav-item:focus-visible {
     outline: 2px solid rgba(59, 130, 246, 0.75);
     outline-offset: 3px;
@@ -467,6 +517,41 @@ body[data-theme="light"] {
     width: 1.125rem;
     height: 1.125rem;
     flex-shrink: 0;
+}
+
+body.sidebar-collapsed .container {
+    gap: var(--space-3);
+}
+
+body.sidebar-collapsed .sidebar {
+    width: 84px;
+    padding: var(--space-6) var(--space-3);
+}
+
+body.sidebar-collapsed .sidebar-controls {
+    justify-content: center;
+    margin-bottom: var(--space-3);
+}
+
+body.sidebar-collapsed .sidebar-toggle {
+    width: 44px;
+}
+
+body.sidebar-collapsed .sidebar .nav-item {
+    justify-content: center;
+    gap: 0;
+    padding: 0;
+    width: 44px;
+    height: 44px;
+    margin: var(--space-2) auto;
+}
+
+body.sidebar-collapsed .sidebar .nav-item span {
+    display: none;
+}
+
+body.sidebar-collapsed .sidebar-nav {
+    align-items: center;
 }
 
 /* ===== UTILITIES ===== */


### PR DESCRIPTION
## Summary
- replace the sidebar toggle icon with a panel-style glyph and switch it based on the collapsed state
- align the collapsed sidebar controls to uniform 44px buttons for consistent sizing

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68ee3cdac6308329a829810e8e5348d9