### PR TITLE
fix: adjust workflows and dev proxy configuration

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -27,7 +27,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm install --no-audit --no-fund
 
       - name: Validate HTML
         uses: Cyb3r-Jak3/html5validator-action@v7
@@ -76,7 +76,7 @@ jobs:
           cache: 'npm'
 
       - name: Install
-        run: npm install
+        run: npm install --no-audit --no-fund
 
       - name: Build
         run: npm run build

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,7 +31,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm install --no-audit --no-fund
 
       - name: Build project
         run: npm run build

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,18 @@ import { fileURLToPath } from 'url';
 import { visualizer } from 'rollup-plugin-visualizer';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const DEFAULT_DEV_SERVER_PORT = 5173;
+const resolvedDevServerPort = Number(process.env.VITE_DEV_SERVER_PORT) || DEFAULT_DEV_SERVER_PORT;
+const resolvedWiremockTarget =
+  process.env.VITE_WIREMOCK_URL || `http://localhost:${process.env.VITE_WIREMOCK_PORT || 8080}`;
+
+const wiremockUrl = new URL(resolvedWiremockTarget);
+const wiremockPort = wiremockUrl.port
+  ? Number(wiremockUrl.port)
+  : wiremockUrl.protocol === 'https:'
+    ? 443
+    : 80;
+const devServerPort = wiremockPort === resolvedDevServerPort ? DEFAULT_DEV_SERVER_PORT : resolvedDevServerPort;
 
 export default defineConfig(({ mode }) => ({
   root: '.',
@@ -70,12 +82,12 @@ export default defineConfig(({ mode }) => ({
     chunkSizeWarningLimit: 500
   },
   server: {
-    port: 5173,
+    port: devServerPort,
     open: true,
     cors: true,
     proxy: {
       '/__admin': {
-        target: 'http://localhost:8080',
+        target: resolvedWiremockTarget,
         changeOrigin: true,
         configure: (proxy) => {
           proxy.on('error', (err) => {


### PR DESCRIPTION
## Summary
- switch workflow dependency installs to npm install to work without a lockfile
- parameterize the Vite dev server and proxy wiring to avoid self-referential loops

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ef417b254c83299a22f31766162b9a