### PR TITLE
Ensure JSON editor uses stored custom headers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,9 @@ _Last updated: 2025-10-12_
 - Grow the JSON editor template catalog and expose quick actions for pinning favourite snippets.【F:editor/monaco-template-library.js†L1-L214】【F:editor/monaco-enhanced.js†L1059-L1160】
 - Consider exposing cache state (current source, optimistic queue depth) directly in the dashboard for easier monitoring while the cache pipeline evolves.【F:js/features.js†L2480-L2662】
 
+## Troubleshooting
+- **HTTP 401 during health check** – The dashboard forwards whatever you enter in **Settings → Custom Headers** directly to the WireMock API client without rewriting values, so the Authorization header must already include the correct scheme (e.g. `Basic <base64>`). A raw value like `RoyaltyPlant:ZarplataV4Raza` will be sent verbatim and rejected by servers expecting Basic auth, resulting in repeated `/__admin/health` failures.【F:js/core.js†L485-L533】【F:js/core.js†L622-L690】【F:docs/README.md†L80-L89】
+
 ## Testing & manual verification
 ### Automated
 - `node tests/cache-workflow.spec.js` – covers optimistic cache create/update/delete flows and ensures the rendered mapping list reflects the cache contents after each operation.【F:tests/cache-workflow.spec.js†L1-L138】

--- a/editor/json-editor.html
+++ b/editor/json-editor.html
@@ -1644,12 +1644,48 @@
             // WireMock URL initialization - single entry point
             const urlParams = new URLSearchParams(window.location.search);
             const settingsParam = urlParams.get('settings');
-            const settings = settingsParam
-                ? JSON.parse(decodeURIComponent(settingsParam))
-                : JSON.parse(localStorage.getItem('wiremock-settings') || '{}');
 
-            const host = settings.host || 'localhost';
-            const port = settings.port || '8080';
+            let paramSettings = {};
+            if (settingsParam) {
+                try {
+                    paramSettings = JSON.parse(decodeURIComponent(settingsParam));
+                } catch (error) {
+                    console.warn('⚠️ Failed to parse settings from URL parameter:', error);
+                    paramSettings = {};
+                }
+            }
+
+            let storedSettings = {};
+            if (typeof window.readWiremockSettings === 'function') {
+                storedSettings = window.readWiremockSettings();
+            } else {
+                try {
+                    storedSettings = JSON.parse(localStorage.getItem('wiremock-settings') || '{}');
+                } catch (error) {
+                    console.warn('⚠️ Failed to parse stored settings from localStorage:', error);
+                    storedSettings = {};
+                }
+            }
+
+            const mergedSettings = {
+                ...(storedSettings && typeof storedSettings === 'object' ? storedSettings : {}),
+                ...(paramSettings && typeof paramSettings === 'object' ? paramSettings : {})
+            };
+
+            const normalizedSettings = (typeof window.normalizeWiremockSettings === 'function')
+                ? window.normalizeWiremockSettings(mergedSettings)
+                : mergedSettings;
+
+            if (typeof window.ensureCustomHeaderObject === 'function') {
+                window.customHeaders = window.ensureCustomHeaderObject(normalizedSettings.customHeaders || {});
+            } else if (normalizedSettings.customHeaders && typeof normalizedSettings.customHeaders === 'object' && !Array.isArray(normalizedSettings.customHeaders)) {
+                window.customHeaders = { ...normalizedSettings.customHeaders };
+            } else {
+                window.customHeaders = {};
+            }
+
+            const host = normalizedSettings.host || 'localhost';
+            const port = normalizedSettings.port || '8080';
 
             window.wiremockBaseUrl = window.normalizeWiremockBaseUrl
                 ? window.normalizeWiremockBaseUrl(host, port)
@@ -1660,7 +1696,12 @@
             const mappingId = urlParams.get('mappingId');
             const mode = urlParams.get('mode');
 
-            console.log('🚀 Parsed parameters:', { mappingId, mode, settings: settings ? 'present' : 'missing' });
+            console.log('🚀 Parsed parameters:', {
+                mappingId,
+                mode,
+                settingsSource: settingsParam ? 'url' : 'storage',
+                customHeaderCount: Object.keys(window.customHeaders || {}).length
+            });
 
             if (mappingId) {
                 console.log(`🔍 Loading mapping with ID: ${mappingId}`);


### PR DESCRIPTION
## Summary
- merge URL-provided and stored WireMock settings when the JSON editor loads
- normalize and apply custom headers so editor API requests reuse the authenticated configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f4f1be30708329aead6d146292d1e1