### PR TITLE
Fix WireMock base URL selection in JSON editor

### DIFF
--- a/js/features/cache.js
+++ b/js/features/cache.js
@@ -196,8 +196,30 @@ window.connectToWireMock = async () => {
     const portInput = document.getElementById('wiremock-port') || document.getElementById(SELECTORS.CONNECTION.PORT);
 
     // Use saved settings or input values
-    const host = hostInput?.value.trim() || settings.wiremockHost || 'localhost';
-    const port = portInput?.value.trim() || settings.wiremockPort || '8080';
+    const trimOrEmpty = (value) => typeof value === 'string' ? value.trim() : '';
+
+    let host = trimOrEmpty(hostInput?.value) || trimOrEmpty(settings.host) || trimOrEmpty(settings.wiremockHost);
+    let port = trimOrEmpty(portInput?.value) || trimOrEmpty(settings.port) || trimOrEmpty(settings.wiremockPort);
+
+    if (!host && window.wiremockBaseUrl) {
+        try {
+            const parsed = new URL(window.wiremockBaseUrl);
+            host = `${parsed.protocol}//${parsed.hostname}`;
+            if (!port && parsed.port) {
+                port = parsed.port;
+            }
+        } catch (error) {
+            console.warn('Failed to derive host from existing wiremockBaseUrl:', window.wiremockBaseUrl, error);
+        }
+    }
+
+    if (!host) {
+        host = 'localhost';
+    }
+
+    if (!port) {
+        port = '';
+    }
     
     // DON'T save connection settings here - they should already be saved from Settings page
     // Only use these values for the current connection attempt


### PR DESCRIPTION
## Summary
- ensure connectToWireMock reads modern host/port settings and reuses the existing base URL when inputs are absent
- prevent the JSON editor from falling back to localhost for WireMock operations so updates target the active server

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f5f8ff75108329afb75d0a8447f087