### PR TITLE
Fix light theme preview background in light mode

### DIFF
--- a/styles/components.css
+++ b/styles/components.css
@@ -790,9 +790,9 @@
 .mapping-preview {
     margin-top: var(--space-4);
     padding: var(--space-4);
-    background: rgba(22, 22, 22, 0.95); /* Solid background to prevent transparency */
+    background: var(--preview-surface); /* Solid background to prevent transparency */
     border-radius: var(--radius-xl);
-    border: 1px solid rgba(255, 255, 255, 0.06);
+    border: 1px solid var(--border-primary);
     /* No max-height or overflow - preview scrolls with the container */
     position: relative; /* Ensure proper stacking */
     z-index: 10; /* Stay above other cards */

--- a/styles/main.css
+++ b/styles/main.css
@@ -33,6 +33,7 @@
     --surface-panel: #161616;
     --surface-elevated: #1d1d1d;
     --surface-card: #262626;
+    --preview-surface: rgba(22, 22, 22, 0.95);
     --bg-accent: rgba(59, 130, 246, 0.12);
     --bg-overlay: rgba(10, 10, 10, 0.85);
 
@@ -106,6 +107,7 @@
     --surface-panel: #ffffff;
     --surface-elevated: #f1f5f9;
     --surface-card: #ffffff;
+    --preview-surface: rgba(255, 255, 255, 0.96);
     --bg-accent: rgba(99, 102, 241, 0.12);
     --bg-overlay: rgba(148, 163, 184, 0.35);
 


### PR DESCRIPTION
## Summary
- introduce a preview surface theme variable shared by both themes
- update mapping/request preview cards to use the themed surface and borders

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f684c534fc8329a6d93bef66a7ca4b