### PR TITLE
Fix modal height issue with viewport units instead of JS calculations

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -124,6 +124,12 @@ function initializeJsonEditorAutoResize() {
 
     if (!jsonEditor || !container) return;
 
+    // Skip auto-resize for modal windows - they use fixed viewport heights in CSS
+    const isInModal = container.closest('.modal');
+    if (isInModal) {
+        return;
+    }
+
     const computedMinHeight = parseInt(window.getComputedStyle(jsonEditor).minHeight, 10);
     if (!Number.isNaN(computedMinHeight)) {
         jsonEditor.dataset.minHeight = computedMinHeight;

--- a/styles/modals.css
+++ b/styles/modals.css
@@ -95,6 +95,9 @@
     flex-direction: column;
     overflow: hidden;
     min-height: 0;
+    /* Fixed height using viewport units - no JS calculations needed */
+    height: 60vh;
+    max-height: calc(90vh - 140px); /* modal max-height minus header, margins and padding */
 }
 
 .modal-header h2 {
@@ -501,14 +504,14 @@ pre {
     background: var(--bg-primary);
     color: var(--text-primary);
     resize: none;
-    min-height: 320px;
     outline: none;
     tab-size: 2;
     flex: 1;
     min-width: 0;
-    min-height: 0;
     box-sizing: border-box;
     overflow: auto;
+    /* Height controlled by parent container, no min-height conflicts */
+    height: 100%;
 }
 
 .json-editor:focus {


### PR DESCRIPTION
Replace complex JavaScript height calculations with simple CSS viewport units for the edit mapping modal. This prevents the modal from having unstable height behavior.

Changes:
- Set fixed height (60vh) and max-height (calc(90vh - 140px)) for json-editor-container in modal
- Removed conflicting min-height from json-editor
- Skip auto-resize JS logic when editor is inside a modal window
- JS calculations now only apply to standalone editor pages

Fixes the height "разъезжается" issue in the clean branch.