### PR TITLE
Add auto-format after mapping loads in Monaco Editor

### DIFF
--- a/editor/monaco-enhanced.js
+++ b/editor/monaco-enhanced.js
@@ -3045,6 +3045,18 @@ class MonacoInitializer {
             const formatted = JSON.stringify(mappingData, null, 2);
             editor.setValue(formatted);
 
+            // Auto-format the document after loading
+            setTimeout(() => {
+                try {
+                    const formatAction = editor.getAction('editor.action.formatDocument');
+                    if (formatAction) {
+                        formatAction.run();
+                    }
+                } catch (e) {
+                    console.warn('Auto-format failed:', e);
+                }
+            }, 100);
+
             this.finalizeEditorMappingLoad();
 
             const resolved = mappingData && (mappingData.mapping || mappingData);


### PR DESCRIPTION
- Automatically format document after loading mapping data
- Uses Monaco's built-in formatDocument action
- 100ms delay ensures editor finishes processing setValue
- Wrapped in try-catch for safety