### PR TITLE
refactor: Remove default presets, keep only custom saved filters

### DIFF
--- a/js/features/filter-presets.js
+++ b/js/features/filter-presets.js
@@ -12,26 +12,28 @@ window.renderFilterPresets = () => {
     if (!container) return;
 
     const presets = window.FilterPresetsManager.getAllPresets();
-    const customPresets = window.FilterPresetsManager.getCustomPresets();
-
     container.innerHTML = '';
 
-    Object.entries(presets).forEach(([presetId, preset]) => {
-        const isCustom = customPresets.hasOwnProperty(presetId);
+    const presetEntries = Object.entries(presets);
+
+    // Show hint if no presets
+    if (presetEntries.length === 0) {
+        container.innerHTML = '<span class="filter-presets-hint">No saved presets. Set filters and click 💾 to save.</span>';
+        return;
+    }
+
+    // Render all saved presets
+    presetEntries.forEach(([presetId, preset]) => {
         const button = document.createElement('button');
         button.type = 'button';
         button.className = 'filter-preset-btn';
         button.onclick = () => window.FilterPresetsManager.applyPreset(presetId, 'mappings');
         button.title = `Apply ${preset.name}`;
 
-        const deleteBtn = isCustom
-            ? `<span class="preset-delete" onclick="event.stopPropagation(); deletePreset('${presetId}');" title="Delete preset">×</span>`
-            : '';
-
         button.innerHTML = `
-            <span class="preset-icon">${preset.icon || '📌'}</span>
+            <span class="preset-icon">${preset.icon || '⭐'}</span>
             <span class="preset-name">${preset.name}</span>
-            ${deleteBtn}
+            <span class="preset-delete" onclick="event.stopPropagation(); deletePreset('${presetId}');" title="Delete preset">×</span>
         `;
 
         container.appendChild(button);

--- a/js/managers.js
+++ b/js/managers.js
@@ -1047,58 +1047,16 @@ window.URLStateManager = {
 // ==========================================
 window.FilterPresetsManager = {
     /**
-     * Default presets for mapping filters
-     */
-    defaultPresets: {
-        'all-errors': {
-            name: 'All Errors',
-            icon: '⚠️',
-            filters: { method: '', query: '', status: '4' }
-        },
-        'server-errors': {
-            name: 'Server Errors (5xx)',
-            icon: '🔥',
-            filters: { method: '', query: '', status: '5' }
-        },
-        'client-errors': {
-            name: 'Client Errors (4xx)',
-            icon: '❌',
-            filters: { method: '', query: '', status: '4' }
-        },
-        'get-requests': {
-            name: 'GET Requests',
-            icon: '📥',
-            filters: { method: 'GET', query: '', status: '' }
-        },
-        'post-requests': {
-            name: 'POST Requests',
-            icon: '📤',
-            filters: { method: 'POST', query: '', status: '' }
-        },
-        'api-endpoints': {
-            name: 'API Endpoints',
-            icon: '🔌',
-            filters: { method: '', query: '/api/', status: '' }
-        },
-        'success-only': {
-            name: 'Success (2xx)',
-            icon: '✅',
-            filters: { method: '', query: '', status: '2' }
-        }
-    },
-
-    /**
-     * Get all presets (default + custom)
-     * @returns {Object} All presets
+     * Get all custom presets
+     * @returns {Object} Custom presets
      */
     getAllPresets() {
         try {
             const customPresets = localStorage.getItem('imock-filter-presets-custom');
-            const custom = customPresets ? JSON.parse(customPresets) : {};
-            return { ...this.defaultPresets, ...custom };
+            return customPresets ? JSON.parse(customPresets) : {};
         } catch (error) {
             console.warn('Failed to load custom presets:', error);
-            return { ...this.defaultPresets };
+            return {};
         }
     },
 

--- a/styles/components.css
+++ b/styles/components.css
@@ -1909,3 +1909,11 @@
         padding: 3px 8px;
     }
 }
+
+.filter-presets-hint {
+    display: block;
+    padding: 8px 12px;
+    font-size: 13px;
+    color: var(--text-secondary);
+    font-style: italic;
+}


### PR DESCRIPTION
Remove all default preset filters and simplify the system to allow users to save only their own custom filter combinations.

**Changes:**

1. **FilterPresetsManager** (js/managers.js):
   - Removed defaultPresets object with 7 predefined filters
   - getAllPresets() now returns only custom saved presets
   - Simplified logic - no more default/custom distinction

2. **Preset UI** (js/features/filter-presets.js):
   - All rendered presets now have delete button (× )
   - Show hint when no presets saved: "No saved presets. Set filters and click 💾 to save."
   - Default icon changed from 📌 to ⭐
   - Removed isCustom check (all are custom now)

3. **CSS** (styles/components.css):
   - Added .filter-presets-hint style for empty state message

**User Flow:**
1. Configure filters (method, query, status)
2. Click 💾 button
3. Enter preset name and emoji icon
4. Preset appears in Quick Filters section
5. Click preset to apply filters
6. Click × to delete preset

**Benefits:**
- ✅ Cleaner UI without unused default presets
- ✅ Users save only what they need
- ✅ All presets are deletable
- ✅ Clear empty state hint
- ✅ Simplified codebase