### PR TITLE
Add saved filters feature with custom badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,6 +325,14 @@
                                     &times;
                                 </button>
                             </div>
+                            <button type="button" class="btn btn-secondary btn-sm" onclick="saveCurrentMappingFilter()" title="Save current filter">
+                                <svg class="icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"></path>
+                                    <polyline points="17 21 17 13 7 13 7 21"></polyline>
+                                    <polyline points="7 3 7 8 15 8"></polyline>
+                                </svg>
+                                <span>Save</span>
+                            </button>
                         </div>
 
                         <!-- Quick filters and active filters -->
@@ -346,6 +354,12 @@
                                 <button type="button" class="filter-chip filter-chip-quick" onclick="applyQuickMethodFilter('DELETE')" data-method="DELETE">
                                     DELETE
                                 </button>
+                            </div>
+                            <div class="saved-filters" id="saved-filters" style="display: none;">
+                                <span class="saved-filters-label">Saved:</span>
+                                <div class="saved-filters-list" id="saved-filters-list">
+                                    <!-- Saved filter chips will be inserted here -->
+                                </div>
                             </div>
                             <div class="active-filters" id="active-filters" style="display: none;">
                                 <span class="active-filters-label">Active:</span>
@@ -465,6 +479,14 @@
                                 &times;
                             </button>
                         </div>
+                        <button type="button" class="btn btn-secondary btn-sm" onclick="saveCurrentRequestFilter()" title="Save current filter">
+                            <svg class="icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"></path>
+                                <polyline points="17 21 17 13 7 13 7 21"></polyline>
+                                <polyline points="7 3 7 8 15 8"></polyline>
+                            </svg>
+                            <span>Save</span>
+                        </button>
                         <div id="req-query-help" class="query-help hidden" role="region" aria-live="polite">
                             <strong>Query Syntax:</strong>
                             <ul>
@@ -490,6 +512,12 @@
                             <button type="button" class="filter-chip filter-chip-quick" onclick="applyQuickRequestFilter('DELETE')">DELETE</button>
                             <button type="button" class="filter-chip filter-chip-quick" onclick="applyQuickRequestFilter('matched:true')">Matched</button>
                             <button type="button" class="filter-chip filter-chip-quick" onclick="applyQuickRequestFilter('matched:false')">Unmatched</button>
+                        </div>
+                        <div class="saved-filters" id="req-saved-filters" style="display: none;">
+                            <span class="saved-filters-label">Saved:</span>
+                            <div class="saved-filters-list" id="req-saved-filters-list">
+                                <!-- Saved filter chips will be inserted here -->
+                            </div>
                         </div>
                         <div class="active-filters" id="req-active-filters">
                             <!-- Active filter chips will be rendered here -->

--- a/js/main.js
+++ b/js/main.js
@@ -683,6 +683,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     }
 
+    // Load saved filters from localStorage
+    if (typeof window.loadAllSavedFilters === 'function') {
+        window.loadAllSavedFilters();
+    }
+
     // Then restore active tab from URL
     const urlTab = typeof window.getActiveTabFromURL === 'function' ? window.getActiveTabFromURL() : null;
     const validTabs = ['mappings', 'requests', 'scenarios', 'import-export', 'recording', 'settings'];

--- a/styles/components.css
+++ b/styles/components.css
@@ -1477,7 +1477,8 @@
 }
 
 .quick-filters,
-.active-filters {
+.active-filters,
+.saved-filters {
     display: flex;
     align-items: center;
     gap: var(--space-2);
@@ -1485,7 +1486,8 @@
 }
 
 .quick-filters-label,
-.active-filters-label {
+.active-filters-label,
+.saved-filters-label {
     font-size: var(--font-size-xs);
     font-weight: 600;
     color: var(--text-secondary);
@@ -1493,7 +1495,8 @@
     letter-spacing: 0.05em;
 }
 
-.active-filters-list {
+.active-filters-list,
+.saved-filters-list {
     display: flex;
     align-items: center;
     gap: var(--space-2);
@@ -1543,6 +1546,37 @@
     color: #ef4444;
 }
 
+.filter-chip-saved {
+    background: rgba(168, 85, 247, 0.2);
+    border-color: rgba(168, 85, 247, 0.5);
+    color: #a855f7;
+    padding-right: 0.5rem;
+    position: relative;
+}
+
+.filter-chip-saved:hover {
+    background: rgba(168, 85, 247, 0.3);
+    border-color: rgba(168, 85, 247, 0.6);
+    transform: translateY(-1px);
+}
+
+.filter-chip-saved .filter-chip-remove {
+    background: transparent;
+    border: none;
+    padding: 0;
+    margin-left: var(--space-1);
+    font-size: 1rem;
+    line-height: 1;
+    color: inherit;
+    opacity: 0.7;
+    cursor: pointer;
+}
+
+.filter-chip-saved:hover .filter-chip-remove {
+    opacity: 1;
+    color: #ef4444;
+}
+
 .filter-chip-remove {
     margin-left: var(--space-1);
     font-size: 1rem;
@@ -1576,6 +1610,17 @@
     background: rgba(239, 68, 68, 0.12);
     border-color: rgba(239, 68, 68, 0.3);
     color: #dc2626;
+}
+
+[data-theme="light"] .filter-chip-saved {
+    background: rgba(168, 85, 247, 0.12);
+    border-color: rgba(168, 85, 247, 0.3);
+    color: #7c3aed;
+}
+
+[data-theme="light"] .filter-chip-saved:hover {
+    background: rgba(168, 85, 247, 0.18);
+    border-color: rgba(168, 85, 247, 0.4);
 }
 
 /* ===== MESSAGES ===== */


### PR DESCRIPTION
Add ability to save custom filters for both mappings and requests tabs. Saved filters appear as purple badges with delete buttons next to quick filters.

Changes:
- Add Save button next to filter input fields
- Add saved-filters section in UI for both tabs
- Implement save/load/delete logic in filters.js
- Store saved filters in localStorage (separate keys for mappings/requests)
- Add purple badge styling for saved filters
- Load saved filters on page load
- Saved filters persist across sessions