### PR TITLE
Move saved filters to same line as Quick filters with compact design

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,10 +354,8 @@
                                 <button type="button" class="filter-chip filter-chip-quick" onclick="applyQuickMethodFilter('DELETE')" data-method="DELETE">
                                     DELETE
                                 </button>
-                            </div>
-                            <div class="saved-filters" id="saved-filters" style="display: none;">
-                                <span class="saved-filters-label">Saved:</span>
-                                <div class="saved-filters-list" id="saved-filters-list">
+                                <span class="filters-separator" id="saved-filters-separator" style="display: none;">|</span>
+                                <div class="saved-filters-inline" id="saved-filters-list" style="display: none;">
                                     <!-- Saved filter chips will be inserted here -->
                                 </div>
                             </div>
@@ -512,10 +510,8 @@
                             <button type="button" class="filter-chip filter-chip-quick" onclick="applyQuickRequestFilter('DELETE')">DELETE</button>
                             <button type="button" class="filter-chip filter-chip-quick" onclick="applyQuickRequestFilter('matched:true')">Matched</button>
                             <button type="button" class="filter-chip filter-chip-quick" onclick="applyQuickRequestFilter('matched:false')">Unmatched</button>
-                        </div>
-                        <div class="saved-filters" id="req-saved-filters" style="display: none;">
-                            <span class="saved-filters-label">Saved:</span>
-                            <div class="saved-filters-list" id="req-saved-filters-list">
+                            <span class="filters-separator" id="req-saved-filters-separator" style="display: none;">|</span>
+                            <div class="saved-filters-inline" id="req-saved-filters-list" style="display: none;">
                                 <!-- Saved filter chips will be inserted here -->
                             </div>
                         </div>

--- a/js/features/filters.js
+++ b/js/features/filters.js
@@ -590,46 +590,45 @@ window.deleteSavedFilter = (tab, name) => {
 function updateSavedFiltersDisplay(tab) {
     const savedFilters = getSavedFilters(tab);
 
-    let containerId, listId;
+    let listId, separatorId;
     if (tab === 'mappings') {
-        containerId = 'saved-filters';
         listId = 'saved-filters-list';
+        separatorId = 'saved-filters-separator';
     } else if (tab === 'requests') {
-        containerId = 'req-saved-filters';
         listId = 'req-saved-filters-list';
+        separatorId = 'req-saved-filters-separator';
     } else {
         return;
     }
 
-    const container = document.getElementById(containerId);
     const list = document.getElementById(listId);
+    const separator = document.getElementById(separatorId);
 
-    if (!container || !list) return;
+    if (!list) return;
 
     if (savedFilters.length === 0) {
-        container.style.display = 'none';
+        list.style.display = 'none';
+        if (separator) separator.style.display = 'none';
         return;
     }
 
-    // Build chips HTML
+    // Build chips HTML - with X inside the button
     const chips = savedFilters.map(filter => `
         <button type="button"
                 class="filter-chip filter-chip-saved"
                 onclick="applySavedFilter('${tab}', '${filter.name.replace(/'/g, "\\'")}')"
                 title="${filter.query}">
-            ${filter.name}
-            <button type="button"
-                    class="filter-chip-remove"
-                    onclick="event.stopPropagation(); deleteSavedFilter('${tab}', '${filter.name.replace(/'/g, "\\'")}')"
-                    title="Delete filter"
-                    aria-label="Delete filter">
-                ×
-            </button>
+            <span class="filter-chip-text">${filter.name}</span>
+            <span class="filter-chip-remove"
+                  onclick="event.stopPropagation(); deleteSavedFilter('${tab}', '${filter.name.replace(/'/g, "\\'")}')"
+                  title="Delete filter"
+                  aria-label="Delete filter">×</span>
         </button>
     `);
 
     list.innerHTML = chips.join('');
-    container.style.display = 'flex';
+    list.style.display = 'inline-flex';
+    if (separator) separator.style.display = 'inline';
 }
 
 // Load saved filters on page load

--- a/styles/components.css
+++ b/styles/components.css
@@ -1477,8 +1477,7 @@
 }
 
 .quick-filters,
-.active-filters,
-.saved-filters {
+.active-filters {
     display: flex;
     align-items: center;
     gap: var(--space-2);
@@ -1486,8 +1485,7 @@
 }
 
 .quick-filters-label,
-.active-filters-label,
-.saved-filters-label {
+.active-filters-label {
     font-size: var(--font-size-xs);
     font-weight: 600;
     color: var(--text-secondary);
@@ -1496,11 +1494,18 @@
 }
 
 .active-filters-list,
-.saved-filters-list {
-    display: flex;
+.saved-filters-inline {
+    display: inline-flex;
     align-items: center;
     gap: var(--space-2);
     flex-wrap: wrap;
+}
+
+.filters-separator {
+    color: var(--text-tertiary);
+    opacity: 0.3;
+    margin: 0 var(--space-1);
+    font-weight: 300;
 }
 
 .filter-chip {
@@ -1550,8 +1555,8 @@
     background: rgba(168, 85, 247, 0.2);
     border-color: rgba(168, 85, 247, 0.5);
     color: #a855f7;
-    padding-right: 0.5rem;
-    position: relative;
+    gap: 0.375rem;
+    padding: 0.25rem 0.5rem 0.25rem 0.75rem;
 }
 
 .filter-chip-saved:hover {
@@ -1560,21 +1565,30 @@
     transform: translateY(-1px);
 }
 
+.filter-chip-saved .filter-chip-text {
+    flex-shrink: 0;
+}
+
 .filter-chip-saved .filter-chip-remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     background: transparent;
     border: none;
     padding: 0;
-    margin-left: var(--space-1);
-    font-size: 1rem;
+    margin: 0;
+    font-size: 1.1rem;
     line-height: 1;
     color: inherit;
-    opacity: 0.7;
+    opacity: 0.6;
     cursor: pointer;
+    transition: all var(--transition-fast);
 }
 
 .filter-chip-saved:hover .filter-chip-remove {
     opacity: 1;
     color: #ef4444;
+    transform: scale(1.1);
 }
 
 .filter-chip-remove {


### PR DESCRIPTION
- Move saved filters to same row as Quick: filters (no separate "Saved:" row)
- Add separator "|" between quick filters and saved filters
- Make delete button (×) inline inside badge for compact look
- Update styling for better visual hierarchy
- Saved filters appear after quick filters in same container

Changes:
- index.html: Restructure saved filters to be inline with quick filters
- filters.js: Update display logic with X as span inside button
- components.css: Add separator styles and compact badge design