### PR TITLE
Fix memory leaks from rapid filter updates

### DIFF
--- a/js/features/filters.js
+++ b/js/features/filters.js
@@ -5,8 +5,10 @@
 // Compact filtering helpers via FilterManager
 window.applyFilters = () => {
     FilterManager.applyMappingFilters();
-    // Update active filters display
-    if (typeof window.updateActiveFiltersDisplay === 'function') {
+    // Update active filters display with debounce
+    if (typeof window._updateActiveFiltersDisplayDebounced === 'function') {
+        window._updateActiveFiltersDisplayDebounced();
+    } else if (typeof window.updateActiveFiltersDisplay === 'function') {
         window.updateActiveFiltersDisplay();
     }
 };
@@ -135,6 +137,11 @@ window.updateActiveFiltersDisplay = () => {
     activeFiltersList.innerHTML = chips.join('');
     activeFiltersContainer.style.display = chips.length > 0 ? 'flex' : 'none';
 };
+
+// Debounced version for oninput events (prevents memory leaks from rapid DOM updates)
+window._updateActiveFiltersDisplayDebounced = window.debounce ?
+    window.debounce(window.updateActiveFiltersDisplay, 200) :
+    window.updateActiveFiltersDisplay;
 
 // Remove active filter from query
 window.removeActiveFilter = (key) => {
@@ -362,8 +369,10 @@ window.applyQuickRequestFilter = (filter) => {
         FilterManager.flushRequestFilters();
     }
 
-    // Update active filters display
-    if (typeof window.updateRequestActiveFiltersDisplay === 'function') {
+    // Update active filters display with debounce
+    if (typeof window._updateRequestActiveFiltersDisplayDebounced === 'function') {
+        window._updateRequestActiveFiltersDisplayDebounced();
+    } else if (typeof window.updateRequestActiveFiltersDisplay === 'function') {
         window.updateRequestActiveFiltersDisplay();
     }
 };
@@ -415,6 +424,11 @@ window.updateRequestActiveFiltersDisplay = () => {
 
     container.innerHTML = chips.join('');
 };
+
+// Debounced version for oninput events (prevents memory leaks from rapid DOM updates)
+window._updateRequestActiveFiltersDisplayDebounced = window.debounce ?
+    window.debounce(window.updateRequestActiveFiltersDisplay, 200) :
+    window.updateRequestActiveFiltersDisplay;
 
 // Remove active filter for requests
 window.removeRequestActiveFilter = (key) => {


### PR DESCRIPTION
Add debouncing to active filter display updates to prevent memory leaks from rapid DOM manipulations during user input.

Issues fixed:
- updateActiveFiltersDisplay was called on every keystroke without debounce
- updateRequestActiveFiltersDisplay had same issue
- Each call created new DOM elements via innerHTML causing memory buildup
- Inline onclick handlers in rapidly created/destroyed elements

Changes:
- Add debounced versions of both display functions (200ms delay)
- Use debounced versions in applyFilters() and applyQuickRequestFilter()
- Prevents DOM thrashing during fast typing
- Reduces memory footprint significantly

Memory impact: Should reduce RAM usage from ~1.5GB to normal levels